### PR TITLE
ci: generate helm-docs automatically

### DIFF
--- a/.github/workflows/generate-helm-docs.yml
+++ b/.github/workflows/generate-helm-docs.yml
@@ -1,0 +1,24 @@
+name: Generate Helm Docs
+
+on:
+  pull_request:
+
+jobs:
+  generate-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate Helm Docs
+        uses: docker://jnorwood/helm-docs:v1.7.0
+        with:
+          entrypoint: /usr/bin/helm-docs
+          args: --chart-search-root /github/workspace
+
+      - name: commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4.13.1
+        with:
+          commit_message: ":robot: update docs [skip ci]"
+          repository: .

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.25.0](https://img.shields.io/badge/AppVersion-0.25.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.27.1](https://img.shields.io/badge/AppVersion-0.27.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -54,7 +54,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightdash/lightdash"` |  |
-| image.tag | string | `"0.25.0"` | Override the image tag |
+| image.tag | string | `"0.27.1"` | Override the image tag |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.className | string | `""` |  |

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -1,0 +1,44 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.badgesSection" . }}
+
+## Prerequisites
+
+### Backend Database
+
+#### Using the Bitnami PostgreSQL chart
+
+You may wish to use the Bitnami PostgreSQL chart to spin up a development environment. This guidance is for convenience, you'll want to [read the docs](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#installing-the-chart) before deciding how to implement PostgresSQL.
+
+```
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm install lightdashdb bitnami/postgresql --set auth.username=lightdash,auth.password=changeme,auth.database=lightdash
+```
+
+Note, a persistent volume claim is created called `data-lightdashdb-postgresql-0` is created at invocation of the above. It is not deleted if `helm uninstall` is called.
+
+Use `--set primary.persistence.enabled=false` to skip creating a persistent volume claim(for development purposes only).
+
+
+## Installing Lightdash
+
+```
+helm repo add lightdash https://lightdash.github.io/helm-charts
+helm install lightdash ligthdash/lightdash \
+  --set configMap.PGHOST=lightdashdb-postgresql.default.svc.cluster.local \
+  --set secrets.PGPASSWORD=changeme \
+
+```
+
+{{ template "chart.requirementsSection" . }}
+
+## Values
+
+Note The `secret.*` values are used to create [kubernetes secrets](https://kubernetes.io/docs/concepts/configuration/secret/). 
+If you don't want helm to manage this, you may wish to separately create a secret named `<release-name>-lightdash`.
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "helm-docs.versionFooter" . }}


### PR DESCRIPTION
use [helm-docs](https://github.com/norwoodj/helm-docs) to automatically generate a doc for the chart, ensuring that the documentation remains accurate to what's in `values.yaml`.