### PR TITLE
fix: Conditional update of existing secrets

### DIFF
--- a/charts/lightdash/templates/external-db.yaml
+++ b/charts/lightdash/templates/external-db.yaml
@@ -1,4 +1,5 @@
 {{- if not .Values.postgresql.enabled }}
+  {{- if .Values.externalDatabase.updateSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,4 +9,5 @@ metadata:
     helm.sh/hook-weight: "-1"
 data:
   postgresql-password: {{ .Values.externalDatabase.password | b64enc }}
+  {{- end }}
 {{- end }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -161,6 +161,7 @@ postgresql:
 ## @param externalDatabase.existingSecretPasswordKey Name of an existing secret key containing the DB password
 ## @param externalDatabase.database Database name
 ## @param externalDatabase.port Database port number
+## @param externalDatabase.updateSecret used to update existing secrets containing DB password
 ##
 externalDatabase:
   host: localhost
@@ -170,6 +171,7 @@ externalDatabase:
   existingSecretPasswordKey: ""
   database: lightdash
   port: 5432
+  updateSecret: false
 
 ## @param additional sidecar containers for the lightdash image
 extraContainers: []


### PR DESCRIPTION
In case postgresql secret already exists, the secret should not necessarily be updated with the new entry from password parameter.