### PR TITLE
fix: remove extraEnv from scheduler

### DIFF
--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 0.8.8](https://img.shields.io/badge/Version-0.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.686.0](https://img.shields.io/badge/AppVersion-0.686.0-informational?style=flat-square)
+![Version: 0.8.9](https://img.shields.io/badge/Version-0.8.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.702.0](https://img.shields.io/badge/AppVersion-0.702.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/templates/scheduler.yaml
+++ b/charts/lightdash/templates/scheduler.yaml
@@ -42,9 +42,6 @@ spec:
                   key: {{ (include "lightdash.database.secret.passwordKey" .) }}
             - name: PORT
               value: {{ .Values.scheduler.port | quote }}
-            {{- if .Values.extraEnv }}
-            {{- toYaml .Values.extraEnv | nindent 12 }}
-            {{- end }}
             {{- if .Values.schedulerExtraEnv }}
             {{- toYaml .Values.schedulerExtraEnv | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
We can't override a scheduler extraEnv with schedulerExtraenv, due to helm merge semantics; so just encourage setting the value on both