### PR TITLE
Add volumes to values.yaml and some info about self-signed certs

### DIFF
--- a/charts/lightdash/templates/deployment.yaml
+++ b/charts/lightdash/templates/deployment.yaml
@@ -27,6 +27,12 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "lightdash.serviceAccountName" . }}
+      volumes:
+        {{- range .Values.volumes }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .name }}
+        {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -35,6 +41,11 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: {{ .Values.image.command }}
           args: {{ .Values.image.args }}
+          volumeMounts:
+            {{- range .Values.volumes }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+            {{- end }}
           env:
             - name: PGPASSWORD
               valueFrom:

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -27,6 +27,8 @@ configMap:
   DBT_PROJECT_DIR: ""
   # -- Public URL of your instance including protocol e.g. https://lightdash.myorg.com
   SITE_URL: ""
+  ## -- Public key of the CA if you are using self-signed certs -- ##
+  ## NODE_EXTRA_CA_CERTS: "/mnt/extra-ca.crt"
 
 secrets:
   # -- 	This is the secret used to sign the session ID cookie and to encrypt sensitive information. Do not share this secret!
@@ -69,6 +71,10 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
+
+volumes:
+  - name: extra-ca
+    mountPath: /mnt
 
 ingress:
   enabled: false


### PR DESCRIPTION
We encountered an issue when using local addresses for Lightdash with self-signed certificates, resulting in an `unable to verify the first certificate` error. This problem can be resolved by adding the `NODE_EXTRA_CA_CERTS` variable. However, it's required to include the certificate itself. You can accomplish this by following these steps:

1. Create a config-map named `extra-ca`:
```
kubectl -n {NAMESPACE} create configmap extra-ca --from-file=./extra-ca.crt
```

2. After creating the configmap, make sure to specify the `NODE_EXTRA_CA_CERTS` variable accordingly.