### PR TITLE
fix: headless browser tag

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.1
+version: 1.5.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -54,7 +54,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | backendConfig.create | bool | `false` |  |
 | browserless-chrome.enabled | bool | `true` |  |
 | browserless-chrome.env.CONNECTION_TIMEOUT | string | `"180000"` |  |
-| browserless-chrome.image.tag | string | `""` |  |
+| browserless-chrome.image.tag | string | `"1.61.1-chrome-stable"` |  |
 | browserless-chrome.replicaCount | int | `1` |  |
 | browserless-chrome.resources.limits.cpu | string | `"500m"` |  |
 | browserless-chrome.resources.limits.memory | string | `"512Mi"` |  |

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 1.5.1](https://img.shields.io/badge/Version-1.5.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1121.0](https://img.shields.io/badge/AppVersion-0.1121.0-informational?style=flat-square)
+![Version: 1.5.2](https://img.shields.io/badge/Version-1.5.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1121.0](https://img.shields.io/badge/AppVersion-0.1121.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -131,7 +131,7 @@ browserless-chrome:
       memory: '512Mi'
       cpu: '500m'
   image:
-    tag: ""
+    tag: "1.61.1-chrome-stable"
   service:
     port: 80
   env:


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/13059

The empty image.tag value was making the browserless chrome image default to 1.48 which is the [browserless-chrome chart](https://artifacthub.io/packages/helm/sagikazarmark/browserless-chrome#values) appVersion,  that is 3 years old

This caused some self-hosted users to have blank images in their scheduled deliveries. 