### PR TITLE
chore: add podLabels to deployments

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.5.5
+version: 1.5.6
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 1.5.5](https://img.shields.io/badge/Version-1.5.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1121.0](https://img.shields.io/badge/AppVersion-0.1121.0-informational?style=flat-square)
+![Version: 1.5.6](https://img.shields.io/badge/Version-1.5.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1121.0](https://img.shields.io/badge/AppVersion-0.1121.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -102,6 +102,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |
 | podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | postgresql.auth.database | string | `"lightdash"` |  |
 | postgresql.auth.existingSecret | string | `""` |  |

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -22,6 +22,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "lightdash.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: backend
     spec:

--- a/charts/lightdash/templates/workerDeployment.yaml
+++ b/charts/lightdash/templates/workerDeployment.yaml
@@ -21,6 +21,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
       labels:
+        {{- with .Values.podLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- include "lightdash.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: worker
     spec:

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -53,6 +53,8 @@ imagePullSecrets: []
 
 podAnnotations: {}
 
+podLabels: {}
+
 podSecurityContext:
   {}
   # fsGroup: 2000


### PR DESCRIPTION
This updates the Chart to 1.5.6 and adds to ability to specify pod labels for the backend and worker deployments, similar to what's already there for annotations.