### PR TITLE
Add SSL configuration options for Database SSL connections

### DIFF
--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -1,3 +1,5 @@
+{{- $volumes := .Values.lightdashBackend.extraVolumes }}
+{{- $volumeMounts := .Values.lightdashBackend.extraVolumeMounts }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -79,6 +81,10 @@ spec:
               port: {{ .Values.service.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.extraVolumes }}
+          {{- toYaml .Values.extraVolumes | nindent 8 }}
+        {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -216,7 +216,6 @@ serviceAccount:
 backendConfig:
   create: false
 
-
 ## Backend deployment specific configuration
 lightdashBackend:
   terminationGracePeriodSeconds: 90
@@ -230,6 +229,8 @@ lightdashBackend:
     initialDelaySeconds: 35
     timeoutSeconds: 30
     periodSeconds: 35
+  extraVolumeMounts: []
+  extraVolumes: []
 
 ## Scheduler deployment specific configuration
 scheduler:
@@ -256,3 +257,5 @@ scheduler:
     initialDelaySeconds: 35
     timeoutSeconds: 30
     periodSeconds: 35
+  extraVolumeMounts: []
+  extraVolumes: []

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -183,6 +183,17 @@ externalDatabase:
   database: lightdash
   port: 5432
 
+## SSL configuration
+## @param ssl.enabled Enable SSL/TLS for the Lightdash Database connection
+## @param ssl.mountPath Path to mount the SSL certificate
+## @param ssl.region Cloud provider region for the RDS instance
+## @param ssl.certFileName Name of the certificate file
+ssl:
+  enabled: false
+  mountPath: "/etc/ssl/certs"
+  region: ""
+  certFileName: ""
+
 ## @param additional main containers for the backend and worker deployments
 extraContainers: []
 


### PR DESCRIPTION
Add configuration options to enable SSL/TLS for the Lightdash database connection.

This allows users to specify the mount path for SSL certificates, the cloud provider region (where applicable) for the Lightdash database instance, and the certificate file name