### PR TITLE
Add support for overriding dnsConfig and dnsPolicy

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.7.4
+version: 1.8.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/templates/_worker-deployment.tpl
+++ b/charts/lightdash/templates/_worker-deployment.tpl
@@ -137,5 +137,12 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ $workerConfig.terminationGracePeriodSeconds | default 90 }}
+      {{- with $root.Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $root.Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -116,3 +116,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.lightdashBackend.terminationGracePeriodSeconds | default 90 }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.dnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -115,6 +115,13 @@ tolerations: []
 
 affinity: {}
 
+# Overrides for deployment DNS configuration
+# dnsPolicy: ClusterFirst
+# dnsConfig:
+#   options:
+#     - name: ndots
+#       value: "1"
+
 ## Browserless Chrome chart configuration
 ## ref: https://github.com/sagikazarmark/helm-charts/tree/master/charts/browserless-chrome
 ## @param browserless-chrome.enabled default true - whether to enable headless browser


### PR DESCRIPTION
## WHAT

Adds support for overriding `dnsConfig` and `dnsPolicy`

## WHY

This allows overriding things like ndots and retries, to reduce redundant DNS traffic.