### PR TITLE
Add toleration and affinity options to migration pod

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.2
+version: 2.7.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.7.2](https://img.shields.io/badge/Version-2.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
+![Version: 2.7.3](https://img.shields.io/badge/Version-2.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -158,6 +158,8 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | migrationJob.extraVolumeMounts | list | `[]` |  |
 | migrationJob.extraVolumes | list | `[]` |  |
 | migrationJob.resources | object | `{}` |  |
+| migrationJob.tolerations | list | `[]` |  |
+| migrationJob.affinity | object | `{}` |  |
 | migrationJob.ssl.certFileName | string | `""` |  |
 | migrationJob.ssl.configMapName | string | `""` |  |
 | migrationJob.ssl.enabled | bool | `false` |  |

--- a/charts/lightdash/templates/migrationJob.yaml
+++ b/charts/lightdash/templates/migrationJob.yaml
@@ -21,6 +21,14 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ include "lightdash.migrationServiceAccountName" . }}
+      {{- with .Values.migrationJob.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.migrationJob.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.initContainers }}
       initContainers:
         {{- toYaml .Values.initContainers | nindent 8 }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -305,6 +305,8 @@ ssl:
 ## @param migrationJob.extraVolumes Extra volumes for the migration pod
 ## @param migrationJob.extraVolumeMounts Extra volume mounts for the migration container
 ## @param migrationJob.resources Resource requests and limits for the migration container (e.g. ephemeral-storage requests)
+## @param migrationJob.tolerations Tolerations for the migration pod
+## @param migrationJob.affinity Affinity rules for the migration pod
 ## @param migrationJob.ssl.enabled Use migrationJob.ssl for the migration Job mount and NODE_EXTRA_CA_CERTS (e.g. a pre-install hook ConfigMap). When false and ssl.enabled is true, the migration Job uses top-level ssl (same ConfigMap as backend).
 ## @param migrationJob.ssl.mountPath Path to mount the migration SSL certificate
 ## @param migrationJob.ssl.certFileName Key/path for the cert file inside the ConfigMap volume
@@ -329,6 +331,22 @@ migrationJob:
   # limits:
   #   memory: 2Gi
   #   ephemeral-storage: 2Gi
+  tolerations: []
+  # Example toleration:
+  # - key: "key"
+  #   operator: "Equal"
+  #   value: "value"
+  #   effect: "NoSchedule"
+  affinity: {}
+  # Example affinity:
+  # nodeAffinity:
+  #   requiredDuringSchedulingIgnoredDuringExecution:
+  #     nodeSelectorTerms:
+  #     - matchExpressions:
+  #       - key: "key"
+  #         operator: "In"
+  #         values:
+  #         - "value"
 
 ## @param additional main containers for the backend and worker deployments
 extraContainers: []


### PR DESCRIPTION
### Summary
Add toleration and affinity options to migration pod.

So that we can add these when using the chart downstream (without these the pods keep getting evicted).