### PR TITLE
fix: allow node cidrs for nats network policy

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.3
+version: 2.7.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.7.3](https://img.shields.io/badge/Version-2.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
+![Version: 2.7.4](https://img.shields.io/badge/Version-2.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -181,6 +181,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | nats.natsBox.enabled | bool | `false` |  |
 | nats.networkPolicy.additionalIngress | list | `[]` |  |
 | nats.networkPolicy.enabled | bool | `true` |  |
+| nats.networkPolicy.nodeCIDRs | list | `[]` |  |
 | nats.podDisruptionBudget.merge.spec.maxUnavailable | int | `0` |  |
 | nats.promExporter.enabled | bool | `true` |  |
 | nats.promExporter.merge.resources.requests.cpu | string | `"100m"` |  |

--- a/charts/lightdash/templates/nats-networkpolicy.yaml
+++ b/charts/lightdash/templates/nats-networkpolicy.yaml
@@ -20,6 +20,14 @@ spec:
       ports:
         - protocol: TCP
           port: 4222
+    {{- range .Values.nats.networkPolicy.nodeCIDRs }}
+    - from:
+        - ipBlock:
+            cidr: {{ . | quote }}
+      ports:
+        - protocol: TCP
+          port: 4222
+    {{- end }}
     {{- with .Values.nats.networkPolicy.additionalIngress }}
     {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -164,6 +164,7 @@ browserless-chrome:
 ## @param nats.enabled Enable NATS JetStream deployment
 ## @param nats.nameOverride Override the name of the NATS subchart
 ## @param nats.networkPolicy.enabled Enable NetworkPolicy to restrict NATS access to Lightdash pods
+## @param nats.networkPolicy.nodeCIDRs Node CIDRs allowed to access NATS when network plugins identify cross-node pod traffic as node traffic
 ## @param nats.networkPolicy.additionalIngress Additional ingress rules (e.g., for Prometheus scraping)
 nats:
   enabled: false
@@ -171,7 +172,12 @@ nats:
 
   networkPolicy:
     enabled: true
+    nodeCIDRs: []
     additionalIngress: []
+    # Example: Allow NATS access from Kubernetes node IPs when Cilium reports
+    # cross-node pod traffic as the remote-node identity.
+    # nodeCIDRs:
+    #   - 10.2.0.0/16
     # Example: Allow Prometheus scraping from gmp-system namespace
     # - from:
     #     - namespaceSelector:


### PR DESCRIPTION
## Summary
- add `nats.networkPolicy.nodeCIDRs` to allow node-sourced traffic to NATS on port 4222
- keep the existing pod selector ingress rule unchanged
- document the new value and bump the chart patch version

## Testing
- `helm lint charts/lightdash`
- `helm template fathom-lightdash charts/lightdash --set nats.enabled=true --set 'nats.networkPolicy.nodeCIDRs[0]=10.2.0.0/16'`