### PR TITLE
chore: bump `browserless-chrome` to `v2.49.0`

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.7.4
+version: 2.7.5
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.7.4](https://img.shields.io/badge/Version-2.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
+![Version: 2.7.5](https://img.shields.io/badge/Version-2.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -100,7 +100,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | browserless-chrome.enabled | bool | `true` |  |
 | browserless-chrome.env.CONNECTION_TIMEOUT | string | `"180000"` |  |
 | browserless-chrome.image.repository | string | `"ghcr.io/browserless/chromium"` |  |
-| browserless-chrome.image.tag | string | `"v2.38.2"` |  |
+| browserless-chrome.image.tag | string | `"v2.49.0"` |  |
 | browserless-chrome.replicaCount | int | `1` |  |
 | browserless-chrome.resources.limits.cpu | string | `"500m"` |  |
 | browserless-chrome.resources.limits.memory | string | `"512Mi"` |  |

--- a/charts/lightdash/values-marketplace.yaml
+++ b/charts/lightdash/values-marketplace.yaml
@@ -45,7 +45,7 @@ browserless-chrome:
   enabled: true
   image:
     repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightdash/browserless-chromium
-    tag: v2.38.2
+    tag: v2.49.0
 
 ## NATS remains disabled. Async workers require a NATS image we do not mirror
 ## (the nats-io chart pulls from Docker Hub), so enabling it requires the

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -153,7 +153,7 @@ browserless-chrome:
       cpu: "500m"
   image:
     repository: "ghcr.io/browserless/chromium"
-    tag: "v2.38.2"
+    tag: "v2.49.0"
   service:
     port: 80
   env:


### PR DESCRIPTION
Updating the `browserless-chrome` image to be in sync with our cloud envs.

TODO:

- [x] Upload image to ECR