### PR TITLE
Allow using existing service account for migrationJob

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.8.0
+version: 2.9.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -161,6 +161,9 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | migrationJob.extraVolumeMounts | list | `[]` |  |
 | migrationJob.extraVolumes | list | `[]` |  |
 | migrationJob.resources | object | `{}` |  |
+| migrationJob.serviceAccount.annotations | object | `{}` |  |
+| migrationJob.serviceAccount.create | bool | `true` |  |
+| migrationJob.serviceAccount.name | string | `""` |  |
 | migrationJob.ssl.certFileName | string | `""` |  |
 | migrationJob.ssl.configMapName | string | `""` |  |
 | migrationJob.ssl.enabled | bool | `false` |  |

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
+![Version: 2.9.0](https://img.shields.io/badge/Version-2.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -182,8 +182,10 @@ Add environment variables to configure database values
  Name of the service account used by the migration hook Job
  */}}
 {{- define "lightdash.migrationServiceAccountName" -}}
-{{- if .Values.serviceAccount.create -}}
-    {{- printf "%s-migration" (include "lightdash.serviceAccountName" .) -}}
+{{- if .Values.migrationJob.serviceAccount.create -}}
+    {{- .Values.migrationJob.serviceAccount.name | default (printf "%s-migration" (include "lightdash.fullname" .)) -}}
+{{- else -}}
+    {{- .Values.migrationJob.serviceAccount.name | default "default" -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/lightdash/templates/migrationServiceAccount.yaml
+++ b/charts/lightdash/templates/migrationServiceAccount.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.migrationJob.enabled .Values.serviceAccount.create }}
+{{- if and .Values.migrationJob.enabled .Values.migrationJob.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -7,8 +7,8 @@ metadata:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-2"
     helm.sh/hook-delete-policy: hook-succeeded,hook-failed
-    {{- with .Values.serviceAccount.annotations }}
-    {{- toYaml . | nindent 4 }}
+    {{- if .Values.migrationJob.serviceAccount.annotations }}
+    {{- toYaml .Values.migrationJob.serviceAccount.annotations | nindent 4 }}
     {{- end }}
   labels:
     {{- include "lightdash.labels" . | nindent 4 }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -320,11 +320,18 @@ ssl:
 ## @param migrationJob.ssl.mountPath Path to mount the migration SSL certificate
 ## @param migrationJob.ssl.certFileName Key/path for the cert file inside the ConfigMap volume
 ## @param migrationJob.ssl.configMapName ConfigMap name for the migration Job (defaults to release-migration-ssl-cert if empty)
+## @param migrationJob.serviceAccount.create Create a dedicated ServiceAccount for the migration hook Job (pre-install/pre-upgrade)
+## @param migrationJob.serviceAccount.name ServiceAccount name (defaults to `<release-fullname>-migration` when create is true, or `default` when create is false)
+## @param migrationJob.serviceAccount.annotations Annotations on the migration ServiceAccount (e.g. workload identity)
 migrationJob:
   enabled: false
   existingSecret: ""
   backoffLimit: 10
   ttlSecondsAfterFinished: 100
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
   ssl:
     enabled: false
     mountPath: "/etc/ssl/certs"


### PR DESCRIPTION
## Summary
This change lets chart users supply an existing ServiceAccount for the migration job instead of always relying on a chart-created one. It adds a new `migrationJob.serviceAccountName` value and updates the migration ServiceAccount name helper to prefer that explicit value when provided.

## Why this change
Some deployments require using pre-existing ServiceAccounts managed outside this chart. This keeps migration job identity configurable without forcing chart-managed ServiceAccount creation.

## Test plan
- [X] `helm lint charts/lightdash`
- [X] `helm template test charts/lightdash --set migrationJob.enabled=true --set migrationJob.serviceAccountName=existing-sa --set serviceAccount.create=false | grep -A 5 -B 5 existing-sa`
```
  ttlSecondsAfterFinished: 100
  template:
    metadata: {}
    spec:
      restartPolicy: Never
      serviceAccountName: existing-sa
      containers:
        - name: migrate
          image: "lightdash/lightdash:0.2248.0"
          imagePullPolicy: IfNotPresent
          workingDir: /usr/app
```
- [X] Verify behavior is unchanged when `migrationJob.serviceAccountName` is empty