### PR TITLE
Add migrationJob.podAnnotations for migration pod metadata

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.9.1
+version: 2.10.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.9.1](https://img.shields.io/badge/Version-2.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
+![Version: 2.10.0](https://img.shields.io/badge/Version-2.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.2248.0](https://img.shields.io/badge/AppVersion-0.2248.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -160,6 +160,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | migrationJob.extraEnv | list | `[]` |  |
 | migrationJob.extraVolumeMounts | list | `[]` |  |
 | migrationJob.extraVolumes | list | `[]` |  |
+| migrationJob.podAnnotations | object | `{}` |  |
 | migrationJob.resources | object | `{}` |  |
 | migrationJob.serviceAccount.annotations | object | `{}` |  |
 | migrationJob.serviceAccount.create | bool | `true` |  |

--- a/charts/lightdash/templates/migrationJob.yaml
+++ b/charts/lightdash/templates/migrationJob.yaml
@@ -13,7 +13,11 @@ spec:
   backoffLimit: {{ .Values.migrationJob.backoffLimit }}
   ttlSecondsAfterFinished: {{ .Values.migrationJob.ttlSecondsAfterFinished }}
   template:
-    metadata: {}
+    metadata:
+      {{- with .Values.migrationJob.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       restartPolicy: Never
       {{- with .Values.imagePullSecrets }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -317,6 +317,7 @@ ssl:
 ## @param migrationJob.resources Resource requests and limits for the migration container (e.g. ephemeral-storage requests)
 ## @param migrationJob.tolerations Tolerations for the migration pod
 ## @param migrationJob.affinity Affinity rules for the migration pod
+## @param migrationJob.podAnnotations Annotations for the migration pod (e.g. cluster-autoscaler.kubernetes.io/safe-to-evict)
 ## @param migrationJob.ssl.enabled Use migrationJob.ssl for the migration Job mount and NODE_EXTRA_CA_CERTS (e.g. a pre-install hook ConfigMap). When false and ssl.enabled is true, the migration Job uses top-level ssl (same ConfigMap as backend).
 ## @param migrationJob.ssl.mountPath Path to mount the migration SSL certificate
 ## @param migrationJob.ssl.certFileName Key/path for the cert file inside the ConfigMap volume
@@ -329,6 +330,7 @@ migrationJob:
   existingSecret: ""
   backoffLimit: 10
   ttlSecondsAfterFinished: 100
+  podAnnotations: {}
   serviceAccount:
     create: true
     name: ""


### PR DESCRIPTION
## Summary
- Add `migrationJob.podAnnotations` to configure annotations on the migration hook Job pod template
- Useful for setting `cluster-autoscaler.kubernetes.io/safe-to-evict: "false"` on long-running DB migrations

## Why this change
The migration job pod template currently hardcodes `metadata: {}`, so chart users cannot opt out of autoscaler/Karpenter eviction during migrations. This mirrors the existing top-level `podAnnotations` support used by backend/worker deployments.

## Test plan
- [x] `helm lint charts/lightdash`
- [x] `helm template test charts/lightdash --set migrationJob.enabled=true --set migrationJob.podAnnotations."cluster-autoscaler\.kubernetes\.io/safe-to-evict"=false --show-only templates/migrationJob.yaml`
- [x] Verified rendered pod template includes the annotation and behavior is unchanged when `migrationJob.podAnnotations` is empty