### PR TITLE
fix(headless-browser): enforce isolated browser egress

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.82
+version: 2.10.83
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.10.82](https://img.shields.io/badge/Version-2.10.82-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.71.0](https://img.shields.io/badge/AppVersion-1.71.0-informational?style=flat-square)
+![Version: 2.10.83](https://img.shields.io/badge/Version-2.10.83-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.71.0](https://img.shields.io/badge/AppVersion-1.71.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -28,6 +28,23 @@ helm install lightdashdb bitnami/postgresql --set auth.username=lightdash,auth.p
 Note, a persistent volume claim is created called `data-lightdashdb-postgresql-0` is created at invocation of the above. It is not deleted if `helm uninstall` is called.
 
 Use `--set primary.persistence.enabled=false` to skip creating a persistent volume claim(for development purposes only).
+
+### Headless browser network isolation
+
+`headlessBrowserEgress.enabled` deploys a forward proxy that rejects private and
+special-use destinations. Its NetworkPolicies also prevent Browserless from
+bypassing that proxy. Keep `headlessBrowserEgress.networkPolicy.enabled` on in
+production and ensure your Kubernetes CNI enforces `NetworkPolicy` resources.
+
+```yaml
+headlessBrowserEgress:
+  enabled: true
+  networkPolicy:
+    enabled: true
+```
+
+This mode requires the bundled `browserless-chrome` deployment. Helm rejects
+the configuration when egress isolation is enabled without it.
 
 ## Installing Lightdash
 
@@ -126,6 +143,33 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | fullnameOverride | string | `""` |  |
 | global.imageRegistry | string | `""` |  |
 | global.storageClass | string | `""` |  |
+| headlessBrowserEgress.affinity | object | `{}` |  |
+| headlessBrowserEgress.enabled | bool | `false` |  |
+| headlessBrowserEgress.image.digest | string | `"sha256:65fe782fa64e07384db718fa1218bd783383fa15ce7e1c232c7fa04674206998"` |  |
+| headlessBrowserEgress.image.pullPolicy | string | `"IfNotPresent"` |  |
+| headlessBrowserEgress.image.repository | string | `"ubuntu/squid"` |  |
+| headlessBrowserEgress.image.tag | string | `"7.2-26.04_edge"` |  |
+| headlessBrowserEgress.internalLightdashHost | string | `""` |  |
+| headlessBrowserEgress.internalLightdashPort | string | `""` |  |
+| headlessBrowserEgress.networkPolicy.additionalBrowserEgress | list | `[]` |  |
+| headlessBrowserEgress.networkPolicy.additionalProxyEgress | list | `[]` |  |
+| headlessBrowserEgress.networkPolicy.dnsNamespaceSelector.matchLabels."kubernetes.io/metadata.name" | string | `"kube-system"` |  |
+| headlessBrowserEgress.networkPolicy.dnsPodSelector.matchLabels.k8s-app | string | `"kube-dns"` |  |
+| headlessBrowserEgress.networkPolicy.enabled | bool | `true` |  |
+| headlessBrowserEgress.nodeSelector | object | `{}` |  |
+| headlessBrowserEgress.podAnnotations | object | `{}` |  |
+| headlessBrowserEgress.podLabels | object | `{}` |  |
+| headlessBrowserEgress.podSecurityContext.seccompProfile.type | string | `"RuntimeDefault"` |  |
+| headlessBrowserEgress.port | int | `3128` |  |
+| headlessBrowserEgress.replicaCount | int | `1` |  |
+| headlessBrowserEgress.resources.limits.cpu | string | `"500m"` |  |
+| headlessBrowserEgress.resources.limits.memory | string | `"256Mi"` |  |
+| headlessBrowserEgress.resources.requests.cpu | string | `"50m"` |  |
+| headlessBrowserEgress.resources.requests.memory | string | `"64Mi"` |  |
+| headlessBrowserEgress.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| headlessBrowserEgress.securityContext.capabilities.drop[0] | string | `"ALL"` |  |
+| headlessBrowserEgress.securityContext.runAsNonRoot | bool | `true` |  |
+| headlessBrowserEgress.tolerations | list | `[]` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"lightdash/lightdash"` |  |
 | image.tag | string | `""` |  |

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -29,6 +29,23 @@ Note, a persistent volume claim is created called `data-lightdashdb-postgresql-0
 
 Use `--set primary.persistence.enabled=false` to skip creating a persistent volume claim(for development purposes only).
 
+### Headless browser network isolation
+
+`headlessBrowserEgress.enabled` deploys a forward proxy that rejects private and
+special-use destinations. Its NetworkPolicies also prevent Browserless from
+bypassing that proxy. Keep `headlessBrowserEgress.networkPolicy.enabled` on in
+production and ensure your Kubernetes CNI enforces `NetworkPolicy` resources.
+
+```yaml
+headlessBrowserEgress:
+  enabled: true
+  networkPolicy:
+    enabled: true
+```
+
+This mode requires the bundled `browserless-chrome` deployment. Helm rejects
+the configuration when egress isolation is enabled without it.
+
 
 ## Installing Lightdash
 

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -220,6 +220,27 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
     {{- printf ((index .Values "browserless-chrome").service.port | toString) -}}
 {{- end -}}
 
+{{/* Headless-browser egress proxy names and internal Lightdash destination. */}}
+{{- define "lightdash.headlessBrowserEgress.fullname" -}}
+{{- printf "%s-headless-browser-egress" (include "lightdash.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "lightdash.headlessBrowserEgress.internalHost" -}}
+{{- default (include "lightdash.fullname" .) .Values.headlessBrowserEgress.internalLightdashHost -}}
+{{- end -}}
+
+{{- define "lightdash.headlessBrowserEgress.internalPort" -}}
+{{- default .Values.service.port .Values.headlessBrowserEgress.internalLightdashPort -}}
+{{- end -}}
+
+{{- define "lightdash.headlessBrowserEgress.proxyUrl" -}}
+{{- printf "http://%s:%v" (include "lightdash.headlessBrowserEgress.fullname" .) .Values.headlessBrowserEgress.port -}}
+{{- end -}}
+
+{{- define "lightdash.headlessBrowserEgress.internalUrl" -}}
+{{- printf "http://%s:%s" (include "lightdash.headlessBrowserEgress.internalHost" .) (include "lightdash.headlessBrowserEgress.internalPort" .) -}}
+{{- end -}}
+
 {{/*
 Renders environment variables for SSL if enabled.
 */}}

--- a/charts/lightdash/templates/configmap.yaml
+++ b/charts/lightdash/templates/configmap.yaml
@@ -1,4 +1,8 @@
 {{- if .Values.configMap }}
+{{- $configMap := .Values.configMap }}
+{{- if and .Values.headlessBrowserEgress.enabled (index .Values "browserless-chrome").enabled }}
+{{- $configMap = omit $configMap "HEADLESS_BROWSER_PROXY_URL" "INTERNAL_LIGHTDASH_HOST" }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -12,6 +16,10 @@ data:
   PGDATABASE: {{ include "lightdash.database.name" . }}
   HEADLESS_BROWSER_HOST: {{ include "lightdash.headlessBrowser.host" . }}
   HEADLESS_BROWSER_PORT: {{ include "lightdash.headlessBrowser.port" .  | quote }}
+  {{- if and .Values.headlessBrowserEgress.enabled (index .Values "browserless-chrome").enabled }}
+  HEADLESS_BROWSER_PROXY_URL: {{ include "lightdash.headlessBrowserEgress.proxyUrl" . | quote }}
+  INTERNAL_LIGHTDASH_HOST: {{ include "lightdash.headlessBrowserEgress.internalUrl" . | quote }}
+  {{- end }}
   {{- if .Values.scheduler.enabled }}
   SCHEDULER_ENABLED: "false"
   {{- else }}
@@ -32,5 +40,5 @@ data:
   {{- if .Values.nats.enabled }}
   NATS_URL: {{ include "lightdash.nats.url" . }}
   {{- end }}
-  {{- toYaml .Values.configMap | nindent 2 }}
+  {{- toYaml $configMap | nindent 2 }}
 {{- end }}

--- a/charts/lightdash/templates/headless-browser-egress-configmap.yaml
+++ b/charts/lightdash/templates/headless-browser-egress-configmap.yaml
@@ -1,0 +1,63 @@
+{{- if and .Values.headlessBrowserEgress.enabled (not (index .Values "browserless-chrome").enabled) }}
+{{- fail "headlessBrowserEgress.enabled requires browserless-chrome.enabled" }}
+{{- end }}
+{{- if and .Values.headlessBrowserEgress.enabled (index .Values "browserless-chrome").enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "lightdash.headlessBrowserEgress.fullname" . }}
+  labels:
+    {{- include "lightdash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: headless-browser-egress
+data:
+  squid.conf: |
+    visible_hostname lightdash-headless-browser-egress
+    http_port {{ .Values.headlessBrowserEgress.port }}
+
+    acl allowed_ports port 1-65535
+    acl internal_lightdash_host dstdomain {{ include "lightdash.headlessBrowserEgress.internalHost" . }}
+    acl internal_lightdash_port port {{ include "lightdash.headlessBrowserEgress.internalPort" . }}
+    acl blocked_hostname dstdomain .localhost .local .internal
+    acl blocked_destination dst 0.0.0.0/8
+    acl blocked_destination dst 10.0.0.0/8
+    acl blocked_destination dst 100.64.0.0/10
+    acl blocked_destination dst 127.0.0.0/8
+    acl blocked_destination dst 169.254.0.0/16
+    acl blocked_destination dst 172.16.0.0/12
+    acl blocked_destination dst 192.0.0.0/24
+    acl blocked_destination dst 192.0.2.0/24
+    acl blocked_destination dst 192.88.99.0/24
+    acl blocked_destination dst 192.168.0.0/16
+    acl blocked_destination dst 198.18.0.0/15
+    acl blocked_destination dst 198.51.100.0/24
+    acl blocked_destination dst 203.0.113.0/24
+    acl blocked_destination dst 224.0.0.0/4
+    acl blocked_destination dst 240.0.0.0/4
+    acl blocked_destination dst ::/128
+    acl blocked_destination dst ::1/128
+    acl blocked_destination dst 64:ff9b::/96
+    acl blocked_destination dst 64:ff9b:1::/48
+    acl blocked_destination dst 100::/64
+    acl blocked_destination dst 2001::/32
+    acl blocked_destination dst 2001:10::/28
+    acl blocked_destination dst 2001:20::/28
+    acl blocked_destination dst 2001:db8::/32
+    acl blocked_destination dst 2002::/16
+    acl blocked_destination dst 3fff::/20
+    acl blocked_destination dst 5f00::/16
+    acl blocked_destination dst fc00::/7
+    acl blocked_destination dst fe80::/10
+    acl blocked_destination dst ff00::/8
+
+    http_access deny !allowed_ports
+    http_access allow internal_lightdash_host internal_lightdash_port
+    http_access deny blocked_hostname
+    http_access deny blocked_destination
+    http_access allow all
+
+    cache deny all
+    access_log stdio:/dev/stdout
+    cache_log /dev/stderr
+    coredump_dir /tmp
+    pid_filename /tmp/squid.pid
+{{- end }}

--- a/charts/lightdash/templates/headless-browser-egress-deployment.yaml
+++ b/charts/lightdash/templates/headless-browser-egress-deployment.yaml
@@ -1,0 +1,74 @@
+{{- if and .Values.headlessBrowserEgress.enabled (index .Values "browserless-chrome").enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "lightdash.headlessBrowserEgress.fullname" . }}
+  labels:
+    {{- include "lightdash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: headless-browser-egress
+spec:
+  replicas: {{ .Values.headlessBrowserEgress.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "lightdash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: headless-browser-egress
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/headless-browser-egress-configmap.yaml") . | sha256sum }}
+        {{- with .Values.headlessBrowserEgress.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "lightdash.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: headless-browser-egress
+        {{- with .Values.headlessBrowserEgress.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.headlessBrowserEgress.podSecurityContext | nindent 8 }}
+      containers:
+        - name: squid
+          securityContext:
+            {{- toYaml .Values.headlessBrowserEgress.securityContext | nindent 12 }}
+          image: "{{ .Values.headlessBrowserEgress.image.repository }}{{ if .Values.headlessBrowserEgress.image.digest }}@{{ .Values.headlessBrowserEgress.image.digest }}{{ else }}:{{ .Values.headlessBrowserEgress.image.tag }}{{ end }}"
+          imagePullPolicy: {{ .Values.headlessBrowserEgress.image.pullPolicy }}
+          ports:
+            - name: proxy
+              containerPort: {{ .Values.headlessBrowserEgress.port }}
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: proxy
+          livenessProbe:
+            tcpSocket:
+              port: proxy
+          resources:
+            {{- toYaml .Values.headlessBrowserEgress.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/squid/squid.conf
+              subPath: squid.conf
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "lightdash.headlessBrowserEgress.fullname" . }}
+      {{- with .Values.headlessBrowserEgress.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.headlessBrowserEgress.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.headlessBrowserEgress.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/lightdash/templates/headless-browser-egress-service.yaml
+++ b/charts/lightdash/templates/headless-browser-egress-service.yaml
@@ -1,0 +1,19 @@
+{{- if and .Values.headlessBrowserEgress.enabled (index .Values "browserless-chrome").enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "lightdash.headlessBrowserEgress.fullname" . }}
+  labels:
+    {{- include "lightdash.labels" . | nindent 4 }}
+    app.kubernetes.io/component: headless-browser-egress
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "lightdash.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: headless-browser-egress
+  ports:
+    - name: proxy
+      port: {{ .Values.headlessBrowserEgress.port }}
+      targetPort: proxy
+      protocol: TCP
+{{- end }}

--- a/charts/lightdash/templates/headless-browser-networkpolicy.yaml
+++ b/charts/lightdash/templates/headless-browser-networkpolicy.yaml
@@ -1,0 +1,138 @@
+{{- if and .Values.headlessBrowserEgress.enabled .Values.headlessBrowserEgress.networkPolicy.enabled (index .Values "browserless-chrome").enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "lightdash.headlessBrowser.fullname" . }}-isolation
+  labels:
+    {{- include "lightdash.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: browserless-chrome
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              {{- include "lightdash.selectorLabels" . | nindent 14 }}
+      ports:
+        - protocol: TCP
+          port: 3000
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "lightdash.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: headless-browser-egress
+      ports:
+        - protocol: TCP
+          port: {{ .Values.headlessBrowserEgress.port }}
+    - to:
+        - namespaceSelector:
+            {{- toYaml .Values.headlessBrowserEgress.networkPolicy.dnsNamespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml .Values.headlessBrowserEgress.networkPolicy.dnsPodSelector | nindent 12 }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    {{- with .Values.headlessBrowserEgress.networkPolicy.additionalBrowserEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "lightdash.headlessBrowserEgress.fullname" . }}
+  labels:
+    {{- include "lightdash.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "lightdash.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: headless-browser-egress
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: browserless-chrome
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: {{ .Values.headlessBrowserEgress.port }}
+  egress:
+    - to:
+        - namespaceSelector:
+            {{- toYaml .Values.headlessBrowserEgress.networkPolicy.dnsNamespaceSelector | nindent 12 }}
+          podSelector:
+            {{- toYaml .Values.headlessBrowserEgress.networkPolicy.dnsPodSelector | nindent 12 }}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+    - to:
+        - podSelector:
+            matchLabels:
+              {{- include "lightdash.selectorLabels" . | nindent 14 }}
+              app.kubernetes.io/component: backend
+      ports:
+        - protocol: TCP
+          port: {{ include "lightdash.headlessBrowserEgress.internalPort" . }}
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except:
+              - 0.0.0.0/8
+              - 10.0.0.0/8
+              - 100.64.0.0/10
+              - 127.0.0.0/8
+              - 169.254.0.0/16
+              - 172.16.0.0/12
+              - 192.0.0.0/24
+              - 192.0.2.0/24
+              - 192.88.99.0/24
+              - 192.168.0.0/16
+              - 198.18.0.0/15
+              - 198.51.100.0/24
+              - 203.0.113.0/24
+              - 224.0.0.0/4
+              - 240.0.0.0/4
+      ports:
+        - protocol: TCP
+          port: 1
+          endPort: 65535
+    - to:
+        - ipBlock:
+            cidr: ::/0
+            except:
+              - ::/128
+              - ::1/128
+              - 64:ff9b::/96
+              - 64:ff9b:1::/48
+              - 100::/64
+              - 2001::/32
+              - 2001:10::/28
+              - 2001:20::/28
+              - 2001:db8::/32
+              - 2002::/16
+              - 3fff::/20
+              - 5f00::/16
+              - fc00::/7
+              - fe80::/10
+              - ff00::/8
+      ports:
+        - protocol: TCP
+          port: 1
+          endPort: 65535
+    {{- with .Values.headlessBrowserEgress.networkPolicy.additionalProxyEgress }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/charts/lightdash/values-marketplace.yaml
+++ b/charts/lightdash/values-marketplace.yaml
@@ -47,6 +47,14 @@ browserless-chrome:
     repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightdash/browserless-chromium
     tag: v2.49.0
 
+## Mirror of ubuntu/squid used by the Browserless egress boundary.
+headlessBrowserEgress:
+  enabled: true
+  image:
+    repository: 709825985650.dkr.ecr.us-east-1.amazonaws.com/lightdash/squid
+    tag: 7.2-26.04_edge
+    digest: ""
+
 ## NATS remains disabled. Async workers require a NATS image we do not mirror
 ## (the nats-io chart pulls from Docker Hub), so enabling it requires the
 ## customer to supply their own image.

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -162,6 +162,55 @@ browserless-chrome:
   env:
     CONNECTION_TIMEOUT: "180000"
 
+## Isolate Chromium behind a forward proxy that rejects private and special-use
+## destinations. NetworkPolicy enforcement requires a compatible CNI.
+## @param headlessBrowserEgress.enabled Deploy the Browserless egress proxy and configure Lightdash to use it; requires browserless-chrome.enabled
+## @param headlessBrowserEgress.internalLightdashHost Hostname Browserless may use to reach Lightdash; defaults to the chart service name
+## @param headlessBrowserEgress.internalLightdashPort Port Browserless may use to reach Lightdash; defaults to service.port
+## @param headlessBrowserEgress.networkPolicy.enabled Prevent Browserless from bypassing the proxy and restrict proxy egress
+headlessBrowserEgress:
+  enabled: false
+  internalLightdashHost: ""
+  internalLightdashPort: ""
+  replicaCount: 1
+  image:
+    repository: ubuntu/squid
+    tag: 7.2-26.04_edge
+    digest: sha256:65fe782fa64e07384db718fa1218bd783383fa15ce7e1c232c7fa04674206998
+    pullPolicy: IfNotPresent
+  port: 3128
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 500m
+      memory: 256Mi
+  podAnnotations: {}
+  podLabels: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  networkPolicy:
+    enabled: true
+    dnsNamespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    dnsPodSelector:
+      matchLabels:
+        k8s-app: kube-dns
+    additionalBrowserEgress: []
+    additionalProxyEgress: []
+
 ## NATS JetStream configuration
 ## ref: https://github.com/nats-io/k8s/tree/main/helm/charts/nats
 ## @param nats.enabled Enable NATS JetStream deployment

--- a/scripts/publish-marketplace.sh
+++ b/scripts/publish-marketplace.sh
@@ -7,9 +7,10 @@
 # Marketplace-managed ECR, so each run:
 #   1. Pulls the Lightdash commercial image from GCP and re-pushes to ECR.
 #   2. Pulls the browserless/chromium image from GHCR and re-pushes to ECR.
-#   3. Packages the chart using values-marketplace.yaml with --app-version
+#   3. Pulls the Squid egress proxy image and re-pushes it to ECR.
+#   4. Packages the chart using values-marketplace.yaml with --app-version
 #      set to the Lightdash version being published.
-#   4. Pushes the packaged chart to ECR as an OCI artifact.
+#   5. Pushes the packaged chart to ECR as an OCI artifact.
 #
 # Prerequisites:
 #   - aws, docker, helm, gcloud, yq installed and authenticated
@@ -31,6 +32,7 @@
 #   - the Marketplace product has ECR repos for:
 #       lightdash/lightdash-containers
 #       lightdash/browserless-chromium
+#       lightdash/squid
 #       lightdash                          (for the Helm chart OCI artifact)
 #     Create any missing repos from the product's Repositories tab first.
 #
@@ -46,6 +48,8 @@
 #   SOURCE_IMAGE               default: us-docker.pkg.dev/lightdash-containers/lightdash/lightdash
 #   BROWSERLESS_SOURCE_IMAGE   default: ghcr.io/browserless/chromium
 #   BROWSERLESS_TAG            default: read from values-marketplace.yaml
+#   EGRESS_PROXY_SOURCE_IMAGE  default: ubuntu/squid
+#   EGRESS_PROXY_TAG           default: read from values-marketplace.yaml
 #   SKIP_IMAGE_MIRROR          set to 1 to skip image pushes (e.g. chart-only republish)
 #   SKIP_CHART_PUBLISH         set to 1 to skip helm package/push
 
@@ -61,10 +65,16 @@ MARKETPLACE_REGISTRY="${MARKETPLACE_REGISTRY:-709825985650.dkr.ecr.us-east-1.ama
 MARKETPLACE_NAMESPACE="${MARKETPLACE_NAMESPACE:-lightdash}"
 SOURCE_IMAGE="${SOURCE_IMAGE:-us-docker.pkg.dev/lightdash-containers/lightdash/lightdash}"
 BROWSERLESS_SOURCE_IMAGE="${BROWSERLESS_SOURCE_IMAGE:-ghcr.io/browserless/chromium}"
+EGRESS_PROXY_SOURCE_IMAGE="${EGRESS_PROXY_SOURCE_IMAGE:-ubuntu/squid}"
 
 BROWSERLESS_TAG="${BROWSERLESS_TAG:-$(grep -A1 "browserless-chromium" "$VALUES_FILE" | grep 'tag:' | awk '{print $2}')}"
 if [[ -z "$BROWSERLESS_TAG" ]]; then
   echo "Could not determine BROWSERLESS_TAG from $VALUES_FILE" >&2
+  exit 1
+fi
+EGRESS_PROXY_TAG="${EGRESS_PROXY_TAG:-$(grep -A2 'repository: ubuntu/squid' "$CHART_DIR/values.yaml" | grep 'tag:' | awk '{print $2}')}"
+if [[ -z "$EGRESS_PROXY_TAG" ]]; then
+  echo "Could not determine EGRESS_PROXY_TAG from $CHART_DIR/values.yaml" >&2
   exit 1
 fi
 
@@ -72,11 +82,13 @@ CHART_VERSION="${CHART_VERSION:-$(grep -E '^version:' "$CHART_DIR/Chart.yaml" | 
 
 LIGHTDASH_DST="$MARKETPLACE_REGISTRY/$MARKETPLACE_NAMESPACE/lightdash-containers:$VERSION"
 BROWSERLESS_DST="$MARKETPLACE_REGISTRY/$MARKETPLACE_NAMESPACE/browserless-chromium:$BROWSERLESS_TAG"
+EGRESS_PROXY_DST="$MARKETPLACE_REGISTRY/$MARKETPLACE_NAMESPACE/squid:$EGRESS_PROXY_TAG"
 
 echo "Publishing to Marketplace:"
 echo "  Lightdash version   : $VERSION"
 echo "  Chart version       : $CHART_VERSION"
 echo "  Browserless version : $BROWSERLESS_TAG"
+echo "  Egress proxy version : $EGRESS_PROXY_TAG"
 echo "  Registry            : $MARKETPLACE_REGISTRY/$MARKETPLACE_NAMESPACE"
 echo
 
@@ -91,6 +103,12 @@ if [[ "${SKIP_IMAGE_MIRROR:-0}" != "1" ]]; then
   docker pull --platform linux/amd64 "$BROWSERLESS_SOURCE_IMAGE:$BROWSERLESS_TAG"
   docker tag "$BROWSERLESS_SOURCE_IMAGE:$BROWSERLESS_TAG" "$BROWSERLESS_DST"
   docker push "$BROWSERLESS_DST"
+
+  echo
+  echo "==> Mirroring Browserless egress proxy"
+  docker pull --platform linux/amd64 "$EGRESS_PROXY_SOURCE_IMAGE:$EGRESS_PROXY_TAG"
+  docker tag "$EGRESS_PROXY_SOURCE_IMAGE:$EGRESS_PROXY_TAG" "$EGRESS_PROXY_DST"
+  docker push "$EGRESS_PROXY_DST"
 fi
 
 if [[ "${SKIP_CHART_PUBLISH:-0}" != "1" ]]; then


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-9307

## Summary

PR 2 of 2 for [PROD-9307](https://linear.app/lightdash/issue/PROD-9307).
This chart change deploys a dedicated Browserless egress proxy and enforces the
network path that the product configures in
[lightdash#26730](https://github.com/lightdash/lightdash/pull/26730).

Stacks after product PR
[#26730](https://github.com/lightdash/lightdash/pull/26730), which adds proxy
launch arguments and application-layer destination validation to every
Browserless session.

## Changes

**Proxy**

- Adds a separate digest-pinned Squid Deployment, Service, and generated ACL
  ConfigMap.
- Allows public TCP destinations and the exact Lightdash backend callback while
  rejecting private and special-use IPv4/IPv6 ranges.
- Uses non-root and restricted container security contexts with explicit resource
  limits.

**Network boundary**

- Restricts Browserless egress to DNS and the proxy.
- Restricts proxy ingress to Browserless and proxy egress to DNS, the Lightdash
  backend, and public address space.
- Exposes explicit extension points for operator-required Browserless or proxy
  egress rules.

**Configuration and release**

- Adds opt-in `headlessBrowserEgress` values and rejects enablement when the
  bundled Browserless deployment is disabled.
- Enforces the proxy URL and internal Lightdash origin in the generated ConfigMap.
- Enables the boundary for Marketplace values and mirrors the Squid image into
  Marketplace ECR.
- Bumps the chart version to `2.10.83`.

## Egress topology

```text
Lightdash backend / worker
          │ CDP
          ▼
     Browserless ──TCP──► Squid ─────► public IPv4 / IPv6
          │                 └────────► Lightdash backend
          └──── direct network path ─X private / special ranges
```

The proxy is a separate pod because a sidecar would share Browserless's network
namespace and could not prevent Chromium from bypassing the proxy.

## Test plan

- [x] Default chart lint.
- [x] Egress-enabled chart lint.
- [x] Marketplace chart lint.
- [x] Kubernetes client dry-run for egress-enabled manifests.
- [x] Kubernetes client dry-run for Marketplace manifests.
- [x] Invalid egress-without-Browserless configuration is rejected.
- [x] Custom Lightdash service port propagates to the callback URL, Squid ACL,
  and NetworkPolicy.
- [x] Conflicting user ConfigMap entries cannot replace the enforced proxy and
  callback values.
- [x] Marketplace publish script passes shell syntax validation.
- [x] Real local Browserless/Squid matrix denies private, loopback, metadata,
  and redirect probes with zero fixture connections while preserving public HTTPS
  and the exact Lightdash callback.
- [ ] Verify NetworkPolicy enforcement and PNG/PDF/scheduled delivery exports in
  staging after the product and chart releases are pinned.

## Rollout order

1. Merge and release [lightdash#26730](https://github.com/lightdash/lightdash/pull/26730).
2. Merge and release this chart as `2.10.83`.
3. Pin both exact versions in Cloud staging and enable the egress values.
4. Verify exports and denied-destination evidence before fleet rollout.

Do not enable these NetworkPolicies against a product image that predates
`HEADLESS_BROWSER_PROXY_URL`; that image would not route Chromium through Squid.
