### PR TITLE
feat: dedicated app-build worker deployment (appBuildWorker)

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.172
+version: 2.10.173
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -15,28 +15,28 @@ version: 2.10.172
 appVersion: 1.134.0
 
 maintainers:
-  - name: owlas
-    email: oliver@lightdash.com
-    url: https://github.com/owlas
-  - name: jim80net
-    email: jim@ramtank.com
-    url: https://github.com/jim80net
+    - name: owlas
+      email: oliver@lightdash.com
+      url: https://github.com/owlas
+    - name: jim80net
+      email: jim@ramtank.com
+      url: https://github.com/jim80net
 icon: https://docs.lightdash.com/img/logo.png
 dependencies:
-  - name: common
-    repository: https://charts.bitnami.com/bitnami
-    tags:
-      - bitnami-common
-    version: 1.x.x
-  - condition: postgresql.enabled
-    version: 11.x.x
-    name: postgresql
-    repository: https://charts.bitnami.com/bitnami
-  - name: browserless-chrome
-    version: 0.0.5
-    repository: https://charts.sagikazarmark.dev
-    condition: browserless-chrome.enabled
-  - name: nats
-    version: 2.12.4
-    repository: https://nats-io.github.io/k8s/helm/charts/
-    condition: nats.enabled
+    - name: common
+      repository: https://charts.bitnami.com/bitnami
+      tags:
+          - bitnami-common
+      version: 1.x.x
+    - condition: postgresql.enabled
+      version: 11.x.x
+      name: postgresql
+      repository: https://charts.bitnami.com/bitnami
+    - name: browserless-chrome
+      version: 0.0.5
+      repository: https://charts.sagikazarmark.dev
+      condition: browserless-chrome.enabled
+    - name: nats
+      version: 2.12.4
+      repository: https://nats-io.github.io/k8s/helm/charts/
+      condition: nats.enabled

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.10.172](https://img.shields.io/badge/Version-2.10.172-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.134.0](https://img.shields.io/badge/AppVersion-1.134.0-informational?style=flat-square)
+![Version: 2.10.173](https://img.shields.io/badge/Version-2.10.173-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.134.0](https://img.shields.io/badge/AppVersion-1.134.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -92,6 +92,32 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
+| appBuildWorker.concurrency | int | `10` |  |
+| appBuildWorker.db.maxConnections | string | `nil` |  |
+| appBuildWorker.enabled | bool | `false` |  |
+| appBuildWorker.extraVolumeMounts | list | `[]` |  |
+| appBuildWorker.extraVolumes | list | `[]` |  |
+| appBuildWorker.livenessProbe.failureThreshold | int | `20` |  |
+| appBuildWorker.livenessProbe.initialDelaySeconds | int | `5` |  |
+| appBuildWorker.livenessProbe.periodSeconds | int | `15` |  |
+| appBuildWorker.livenessProbe.timeoutSeconds | int | `15` |  |
+| appBuildWorker.port | int | `8080` |  |
+| appBuildWorker.readinessProbe.failureThreshold | int | `2` |  |
+| appBuildWorker.readinessProbe.initialDelaySeconds | int | `5` |  |
+| appBuildWorker.readinessProbe.periodSeconds | int | `5` |  |
+| appBuildWorker.readinessProbe.timeoutSeconds | int | `5` |  |
+| appBuildWorker.replicas | int | `1` |  |
+| appBuildWorker.resources.requests.cpu | string | `"475m"` |  |
+| appBuildWorker.resources.requests.ephemeral-storage | string | `"1Gi"` |  |
+| appBuildWorker.resources.requests.memory | string | `"725Mi"` |  |
+| appBuildWorker.startupProbe.failureThreshold | int | `18` |  |
+| appBuildWorker.startupProbe.initialDelaySeconds | int | `5` |  |
+| appBuildWorker.startupProbe.periodSeconds | int | `10` |  |
+| appBuildWorker.startupProbe.timeoutSeconds | int | `10` |  |
+| appBuildWorker.tasks.exclude | string | `nil` |  |
+| appBuildWorker.tasks.include | string | `"appGeneratePipeline"` |  |
+| appBuildWorker.terminationGracePeriodSeconds | int | `90` |  |
+| appBuildWorker.type | string | `"graphile"` |  |
 | autoscaling.enabled | bool | `false` |  |
 | autoscaling.maxReplicas | int | `100` |  |
 | autoscaling.minReplicas | int | `1` |  |

--- a/charts/lightdash/templates/appBuildWorkerDeployment.yaml
+++ b/charts/lightdash/templates/appBuildWorkerDeployment.yaml
@@ -1,0 +1,2 @@
+{{- /* App-build worker deployment using reusable template - DO NOT REMOVE THIS COMMENT OTHERWISE FORMATTING WILL BREAK */ -}}
+{{- include "lightdash.workerDeployment" (dict "root" . "component" "app-build-worker" "workerConfig" .Values.appBuildWorker) -}}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -459,6 +459,47 @@ scheduler:
   extraVolumeMounts: []
   extraVolumes: []
 
+## Dedicated graphile worker for data app builds (appGeneratePipeline).
+## When enabling, set scheduler.tasks.exclude=appGeneratePipeline so builds
+## only run on this pool.
+appBuildWorker:
+  type: graphile
+  port: 8080
+  enabled: false
+  replicas: 1
+  concurrency: 10
+  db:
+    maxConnections:
+  resources:
+    requests:
+      memory: 725Mi
+      cpu: 475m
+      ephemeral-storage: 1Gi
+  terminationGracePeriodSeconds: 90
+  startupProbe:
+    ## 5 + (10 * 18) = ~185s max startup
+    initialDelaySeconds: 5
+    timeoutSeconds: 10
+    periodSeconds: 10
+    failureThreshold: 18
+  livenessProbe:
+    ## 5 + (15 * 20) = ~305s to restart
+    initialDelaySeconds: 5
+    timeoutSeconds: 15
+    periodSeconds: 15
+    failureThreshold: 20
+  readinessProbe:
+    ## 5 + (5 * 2) = ~15s to remove from LB
+    initialDelaySeconds: 5
+    timeoutSeconds: 5
+    periodSeconds: 5
+    failureThreshold: 2
+  tasks:
+    exclude:
+    include: appGeneratePipeline
+  extraVolumeMounts: []
+  extraVolumes: []
+
 ## Dedicated warehouse async query worker configuration
 warehouseNatsWorker:
   type: nats


### PR DESCRIPTION
Part of [GLITCH-662](https://linear.app/lightdash/issue/GLITCH-662/isolate-scheduler-workers-for-data-app-tasks)

## Why

During the 2026-08-11 seenons stress test on eu1, data app builds queued in `pending` for up to ~7.4 minutes: `appGeneratePipeline` jobs share the scheduler worker's graphile slots (`SCHEDULER_CONCURRENCY`, default 3) with every other scheduler task, and each build holds a slot for 1–9+ minutes. Builds looked stuck ("no E2B sandbox created") when they were just waiting for a slot — and conversely a build storm can starve scheduled deliveries.

## What

Adds an optional second graphile worker deployment, `appBuildWorker`, that only processes `appGeneratePipeline` (via `SCHEDULER_INCLUDE_TASKS`, already supported by the shared `lightdash.workerDeployment` template — this PR just instantiates the template a second time).

- Disabled by default; zero rendered output unless `appBuildWorker.enabled=true`
- Default `concurrency: 10` (builds are idle-waiting on the Claude API, so slots are cheap)
- When enabling, pair with `scheduler.tasks.exclude=appGeneratePipeline` so builds run only on the dedicated pool
- Safe with cron: graphile cron enqueues by task identifier and workers only lock jobs for tasks they registered; multi-runner cron dedup is already exercised by instances running scheduler replicas > 1

## Verified

- `helm template` with `appBuildWorker.enabled=true`: renders deployment with `SCHEDULER_INCLUDE_TASKS=appGeneratePipeline`, `SCHEDULER_CONCURRENCY=10`, component `app-build-worker`
- `scheduler.tasks.exclude=appGeneratePipeline`: main worker gets `SCHEDULER_EXCLUDE_TASKS`
- Default values: template renders nothing
- `helm lint` passes

Staging trial: [GLITCH-664](https://linear.app/lightdash/issue/GLITCH-664/trial-run-on-staging) / lightdash/lightdash-cloud#3054

🤖 Generated with [Claude Code](https://claude.com/claude-code)