### PR TITLE
fix: add before-hook-creation to migration hook delete policies

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.174
+version: 2.10.175
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.10.174](https://img.shields.io/badge/Version-2.10.174-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.134.1](https://img.shields.io/badge/AppVersion-1.134.1-informational?style=flat-square)
+![Version: 2.10.175](https://img.shields.io/badge/Version-2.10.175-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.134.1](https://img.shields.io/badge/AppVersion-1.134.1-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/templates/migrationConfigMap.yaml
+++ b/charts/lightdash/templates/migrationConfigMap.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-1"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
   labels:
     {{- include "lightdash.labels" . | nindent 4 }}
 data:

--- a/charts/lightdash/templates/migrationSecrets.yaml
+++ b/charts/lightdash/templates/migrationSecrets.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-1"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
   labels:
     {{- include "lightdash.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/lightdash/templates/migrationServiceAccount.yaml
+++ b/charts/lightdash/templates/migrationServiceAccount.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     helm.sh/hook: pre-install,pre-upgrade
     helm.sh/hook-weight: "-2"
-    helm.sh/hook-delete-policy: hook-succeeded,hook-failed
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     {{- if .Values.migrationJob.serviceAccount.annotations }}
     {{- toYaml .Values.migrationJob.serviceAccount.annotations | nindent 4 }}
     {{- end }}


### PR DESCRIPTION
## Why

Staging's helm upgrade (lightdash/lightdash-cloud#3054 deploy) failed with:

```
Error: pre-upgrade hooks failed: warning: Hook pre-upgrade lightdash/templates/migrationServiceAccount.yaml failed: serviceaccounts "staging-lightdash-migration" already exists
```

The migration **ServiceAccount / ConfigMap / Secrets** pre-upgrade hooks carry `helm.sh/hook-delete-policy: hook-succeeded,hook-failed` only. If an upgrade is interrupted between hook-resource creation and hook completion (cancelled CI run, crashed apply — staging's leftovers were 21 days old), the resources are never deleted, and **every subsequent upgrade collides with them**. `migrationJob.yaml` already has `before-hook-creation`, which replaces stale leftovers instead of failing.

## What

Adds `before-hook-creation` to the delete policy of the three migration hook resources, matching the job's policy. `helm lint` passes.

(Staging was unblocked manually by deleting the three leftover resources; this prevents recurrence everywhere.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)