### PR TITLE
fix: provide NATS_URL to migration job configmap

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.180
+version: 2.10.181
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.10.180](https://img.shields.io/badge/Version-2.10.180-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.136.1](https://img.shields.io/badge/AppVersion-1.136.1-informational?style=flat-square)
+![Version: 2.10.181](https://img.shields.io/badge/Version-2.10.181-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.136.1](https://img.shields.io/badge/AppVersion-1.136.1-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/templates/migrationConfigMap.yaml
+++ b/charts/lightdash/templates/migrationConfigMap.yaml
@@ -14,5 +14,8 @@ data:
   PGHOST: {{ include "lightdash.database.host" . }}
   PGPORT: {{ include "lightdash.database.port" . | quote }}
   PGDATABASE: {{ include "lightdash.database.name" . }}
+  {{- if .Values.nats.enabled }}
+  NATS_URL: {{ include "lightdash.nats.url" . }}
+  {{- end }}
   {{- toYaml .Values.configMap | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
## Why

Staging's helm upgrade (chart 2.10.173, app 1.134.0) fails its pre-upgrade migration hook — the migrate container crashes at config-parse:

```
ParseError: NATS_URL is required when NATS_ENABLED=true
    at parseConfig (.../dist/config/parseConfig.js:1216)
```

The shared configmap sets `NATS_URL` via the `lightdash.nats.url` template include (`configmap.yaml`), but `migrationConfigMap.yaml` only copies `.Values.configMap` — which carries `NATS_ENABLED=true` (set fleet-wide by lightdash-cloud defaults) without the URL. **Every NATS-enabled instance fails its migration hook on any full helm upgrade** with app images that enforce this check; it's invisible day-to-day because fast deploys (`kubectl set image`) never run helm hooks.

## What

Mirrors the same conditional `NATS_URL` include into the migration configmap. Verified with `helm template`:

```
PGDATABASE: lightdash
NATS_URL: nats://test-nats:4222
NATS_ENABLED: true
```

`helm lint` passes. Part of the staging trial fallout from [GLITCH-664](https://linear.app/lightdash/issue/GLITCH-664/trial-run-on-staging); companion to #141.

🤖 Generated with [Claude Code](https://claude.com/claude-code)