### PR TITLE
feat: add optional AWS CDK deployment for self-hosted Lightdash on EKS

### DIFF
--- a/deploy/aws-cdk/.gitignore
+++ b/deploy/aws-cdk/.gitignore
@@ -1,0 +1,16 @@
+node_modules
+cdk.out
+cdk.context.json
+*.tsbuildinfo
+
+# Compiled output. The app runs through ts-node, so these only appear when
+# someone runs `npm run build`.
+*.js
+*.d.ts
+
+# The repository root ignores package-lock.json for every directory. Infra
+# code is re-included here: without the lockfile, `npm install` resolves a
+# different aws-cdk-lib months later and a redeploy is no longer the same
+# deployment. A subdirectory rule wins over the parent, so the root file stays
+# untouched.
+!package-lock.json

--- a/deploy/aws-cdk/README.md
+++ b/deploy/aws-cdk/README.md
@@ -1,0 +1,286 @@
+# Lightdash on Amazon EKS with AWS CDK
+
+Optional deployment path that provisions the AWS infrastructure for a self-hosted
+Lightdash instance and then installs the `lightdash` Helm chart from this repository's
+published chart repository.
+
+The chart is used unchanged. Nothing here modifies `charts/lightdash`, and `helm install`
+remains a first-class way to install Lightdash into a cluster you already have. This
+project exists for people who have an AWS account and no cluster.
+
+## What it creates
+
+| Resource | Default | Notes |
+|---|---|---|
+| VPC | `10.0.0.0/16`, 2 AZs, 1 NAT gateway | Public, private-with-egress, and isolated subnets |
+| EKS cluster | Kubernetes 1.31 | Public and private endpoint access |
+| Managed node group | 2 x `t3.large`, 30 GB | Private subnets |
+| AWS Load Balancer Controller | v2.13.4 | Provisions an ALB from the chart's Ingress |
+| RDS PostgreSQL | `t4g.micro`, 20 GB, gp3 | Isolated subnets, not publicly accessible, encrypted |
+| S3 bucket | Encrypted, public access blocked | Lightdash results and uploads |
+| Secrets Manager | 2 secrets | Database password, `LIGHTDASH_SECRET` |
+| External Secrets Operator | v0.10.4 | Copies both secrets into the cluster |
+| Lightdash | chart 2.10.241 | Installed from `https://lightdash.github.io/helm-charts` |
+
+Roughly 80 CloudFormation resources in one stack.
+
+### Cost
+
+At the defaults, in `us-east-1`, the recurring charges are approximately:
+
+| Item | Monthly |
+|---|---|
+| EKS control plane | 73 USD |
+| 2 x `t3.large` nodes | 120 USD |
+| NAT gateway (plus data processing) | 33 USD |
+| RDS `t4g.micro` with 20 GB | 15 USD |
+| Application Load Balancer | 17 USD |
+| S3, Secrets Manager, logs | 2 USD |
+
+That is on the order of 260 USD per month. It is not a free-tier deployment, and the
+largest single line is the EKS control plane, which is charged whether or not anything is
+running on it. Run `cdk destroy` when you are finished evaluating.
+
+## Prerequisites
+
+- Node.js 20 or newer. The repository's `flake.nix` provides `nodejs_20`.
+- An AWS account, credentials in the environment, and the region you intend to use.
+- CDK bootstrapped in that account and region: `npx cdk bootstrap aws://ACCOUNT/REGION`.
+- `kubectl` and `helm`, to inspect the result. Neither is needed to deploy.
+
+## Deploy
+
+With a domain and an ACM certificate, which is what anything beyond evaluation wants:
+
+```bash
+cd deploy/aws-cdk
+npm install
+npx cdk synth                       # no AWS writes, and no credentials needed
+npx cdk deploy \
+  -c hostname=lightdash.example.com \
+  -c certificateArn=arn:aws:acm:us-east-1:111122223333:certificate/abc
+```
+
+Without a certificate the load balancer is internet-facing and speaks plain HTTP, so
+`allowInsecureHttp` has to be set before synth will produce it:
+
+```bash
+npx cdk deploy -c allowInsecureHttp=true
+```
+
+Anyone who learns the load balancer's DNS name can then reach the login page, and
+credentials and session cookies cross the internet in clear text. Use it to see Lightdash
+running, not for an instance you intend to keep.
+
+The first deploy takes roughly 25 to 35 minutes, most of it the EKS control plane and the
+RDS instance. When it finishes, the stack outputs a `kubectl` command for the cluster and a
+command that prints the load balancer hostname:
+
+```bash
+aws eks update-kubeconfig --region REGION --name CLUSTER_NAME
+kubectl -n lightdash get ingress lightdash \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+The load balancer takes a further two to three minutes to appear after the release
+succeeds, because the controller provisions it asynchronously.
+
+### Getting kubectl access
+
+Creating a cluster does not give the identity that created it a way in through the CLI. The
+role CDK builds for its own kubectl provider holds the cluster-admin binding, and your own
+credentials are not part of it, so `kubectl` answers `You must be logged in to the server`
+until an entry exists for them.
+
+Pass the role you deploy with and the stack grants it cluster-admin:
+
+```bash
+npx cdk deploy -c adminRoleArn=arn:aws:iam::111122223333:role/YourRole
+```
+
+Or add yourself afterwards, which needs only IAM permissions and not cluster access:
+
+```bash
+aws eks create-access-entry --cluster-name CLUSTER_NAME --principal-arn YOUR_ROLE_ARN
+aws eks associate-access-policy --cluster-name CLUSTER_NAME --principal-arn YOUR_ROLE_ARN \
+  --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
+  --access-scope type=cluster
+```
+
+Use the role ARN, not the `assumed-role` ARN that `aws sts get-caller-identity` prints. The
+cluster runs in `API_AND_CONFIG_MAP` mode so that this second path works at all; under
+`CONFIG_MAP` alone the only way in is through a ConfigMap that only someone already inside
+the cluster can edit.
+
+## Configuration
+
+Every input is CDK context, so pass it with `-c` or commit it to `cdk.context.json`:
+
+```bash
+npx cdk deploy \
+  -c hostname=lightdash.example.com \
+  -c certificateArn=arn:aws:acm:us-east-1:111122223333:certificate/abc \
+  -c nodeInstanceType=t3.xlarge
+```
+
+| Context key | Default | Purpose |
+|---|---|---|
+| `region`, `account` | From your credentials | Deployment target |
+| `hostname` | none | Public hostname. See "Running without a domain" |
+| `certificateArn` | none | ACM certificate for HTTPS. Requires `hostname` |
+| `vpcCidr` | `10.0.0.0/16` | VPC range |
+| `natGateways` | `1` | Raise to the AZ count for production |
+| `maxAzs` | `2` | Availability zones |
+| `kubernetesVersion` | `1.31` | See the note below before changing |
+| `nodeInstanceType` | `t3.large` | Node size |
+| `nodeDiskSizeGb` | `30` | Node disk |
+| `nodeMinSize`, `nodeMaxSize`, `nodeDesiredSize` | `2`, `4`, `2` | Node group sizing |
+| `dbInstanceType` | `t4g.micro` | Database size |
+| `dbAllocatedStorageGb` | `20` | Database storage, autoscaling to `dbMaxAllocatedStorageGb` |
+| `dbBackupRetentionDays` | `7` | Automated backup retention, up to the RDS maximum of 35 |
+| `dbDeletionProtection` | `false` | Blocks deletion of the database, including by destroy |
+| `postgresVersion`, `postgresMajorVersion` | `16`, `16` | Engine version. See the note below |
+| `namespace`, `releaseName` | `lightdash` | Kubernetes namespace and Helm release |
+| `chartVersion` | `2.10.241` | Chart version to install |
+| `chartRepository` | `https://lightdash.github.io/helm-charts` | Chart source |
+| `allowInsecureHttp` | `false` | Required to deploy with no certificate. See below |
+| `retainData` | `false` | Final database snapshot on destroy, and keep the bucket and secrets |
+| `adminRoleArn` | none | IAM role granted cluster-admin. See "Getting kubectl access" |
+
+`postgresVersion` is the major family rather than a pinned minor, which RDS resolves to the
+latest minor it supports. A pinned minor stops being deployable once AWS retires it, and
+minor upgrades are applied in the maintenance window regardless, so pinning one would only
+decide which version the first hour of the instance's life runs. Pass a full version such
+as `-c postgresVersion=16.14` if you need a specific minor at creation.
+
+Raising `kubernetesVersion` past 1.31 also requires depending on the matching
+`@aws-cdk/lambda-layer-kubectl-vNN` package and importing it in
+`lib/constructs/cluster.ts`. CDK pins the kubectl binary by package name, so the version
+cannot follow the context value on its own.
+
+## Running without a domain
+
+With no `hostname`, the Ingress matches any host and Lightdash is reachable at the load
+balancer's own DNS name, which requires `allowInsecureHttp=true` since there is nothing to
+issue a certificate against. `SITE_URL` is left empty in that case, so links Lightdash
+generates for itself, including invite and password-reset emails, will not point back at
+your instance. `SECURE_COOKIES` is off, because a secure cookie is never sent over HTTP.
+
+To fix that once you know the address, redeploy with it:
+
+```bash
+npx cdk deploy -c hostname=$(kubectl -n lightdash get ingress lightdash \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+```
+
+For anything beyond evaluation, point a domain at the load balancer, issue an ACM
+certificate, and pass both `hostname` and `certificateArn`. That also turns on
+`SECURE_COOKIES` and an HTTP to HTTPS redirect.
+
+## How credentials reach the pods
+
+The database password and `LIGHTDASH_SECRET` are generated into Secrets Manager and never
+placed in Helm values. The External Secrets Operator reads them from inside the cluster
+using an IRSA role and materialises two Kubernetes Secrets, which the chart consumes
+through its existing `externalDatabase.existingSecret` and `existingSecret` values.
+
+The consequence is that no plaintext credential appears in the CloudFormation template, in
+`cdk.context.json`, or in the kubectl provider's event payload. The only copies are in
+Secrets Manager and in etcd. Rotating the RDS secret does not require a redeploy, because
+the operator refreshes hourly.
+
+S3 access uses IRSA rather than access keys. Lightdash omits explicit credentials when
+`S3_ACCESS_KEY` is unset and falls back to the AWS SDK credential chain;
+`S3_USE_CREDENTIALS_FROM=token_file` pins it to the projected service account token, so a
+broken IRSA setup fails on the first S3 operation rather than quietly falling through to
+the node instance profile. Credential resolution is lazy, so the pod still starts and
+serves health checks either way.
+
+### Database TLS
+
+RDS PostgreSQL 15 and later refuse unencrypted connections, so `PGSSLMODE=no-verify` is set.
+That encrypts the connection without verifying the server certificate, which is a
+reasonable position for traffic that never leaves a private subnet.
+
+`no-verify` rather than `require`, which under libpq would mean the same thing. Lightdash
+reaches PostgreSQL through node-postgres, where `require` leaves Node's TLS verification on
+and the RDS certificate chain is checked against the image's trust store, which contains no
+Amazon RDS root. Every start then fails with `self-signed certificate in certificate chain`
+before the migrations run.
+
+For certificate verification, put the RDS CA bundle in a ConfigMap and use the chart's
+existing SSL support, which sets `PGSSLMODE=verify-full` and points
+`NODE_EXTRA_CA_CERTS` at the bundle:
+
+```bash
+curl -o global-bundle.pem https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem
+kubectl -n lightdash create configmap lightdash-ssl-cert --from-file=global-bundle.pem
+```
+
+then set `ssl.enabled=true`, `ssl.certFileName=global-bundle.pem` and
+`ssl.configMapName=lightdash-ssl-cert` in the release. The bundle is not vendored here
+because it rotates on Amazon's schedule, not this repository's.
+
+## Teardown
+
+```bash
+npx cdk destroy
+```
+
+With the default `retainData=false` this removes everything, including the database and the
+bucket's contents. With `retainData=true` the database is deleted but leaves a final
+snapshot behind, and the bucket and secrets are retained, so you are responsible for
+deleting all three later.
+
+Deletion protection is off by default and is not tied to `retainData`, because RDS rejects
+the delete that either removal policy asks for while protection is on, and destroy then
+stops in `DELETE_FAILED` with no snapshot taken. For an instance you want guarded against
+an accidental destroy, pass `-c dbDeletionProtection=true` and expect to redeploy with it
+off before you can tear the stack down. Set it here rather than in the console, where the
+next deploy would quietly revert it.
+
+The load balancer is created by the controller rather than by CloudFormation, and is removed
+when the Ingress is deleted with the Helm release. That only works while the controller is
+still running, because the finalizer it puts on the Ingress is one only it removes, so the
+release is ordered ahead of the controller and the namespace ahead of the node group. If a
+destroy is interrupted between those steps, the namespace can be left in `Terminating` with
+the load balancer still up. Clear it by removing the finalizers, then delete the load
+balancer, its target group and its security groups by hand:
+
+```bash
+kubectl -n lightdash patch ingress lightdash --type=merge -p '{"metadata":{"finalizers":null}}'
+kubectl -n lightdash get targetgroupbindings -o name | xargs -I{} \
+  kubectl -n lightdash patch {} --type=merge -p '{"metadata":{"finalizers":null}}'
+```
+
+## Layout
+
+```
+bin/lightdash.ts              App entry. Resolves context and instantiates the stack
+lib/config.ts                 Every input, its default, and validation
+lib/lightdash-stack.ts        Composes the constructs and declares outputs
+lib/constructs/network.ts     VPC, subnets, load balancer discovery tags
+lib/constructs/cluster.ts     EKS, node group, load balancer controller
+lib/constructs/database.ts    RDS PostgreSQL
+lib/constructs/storage.ts     S3 bucket
+lib/constructs/secret-sync.ts External Secrets Operator and the two ExternalSecrets
+lib/constructs/application.ts IRSA service account and the Helm release
+```
+
+One stack rather than several: splitting network, data and cluster stacks means exporting a
+VPC and a security group across stack boundaries, and CloudFormation then refuses to update
+an export while another stack references it. That turns routine changes into manual export
+surgery.
+
+## Limitations
+
+- Single AZ database, single NAT gateway, no read replica. This is a small self-hosted
+  deployment, not a highly available one.
+- No CI in this repository covers this directory. `ct lint` only looks at `charts/**`.
+- Upgrades are performed by changing `chartVersion` and redeploying. There is no
+  blue/green or canary path.
+- The Helm release waits 13 minutes, held under the 15 CDK gives its kubectl provider
+  Lambda so that helm reports its own timeout before the Lambda is killed. A cold-start
+  migration on a heavily loaded `t4g.micro` can exceed it. The release continues in the
+  cluster, and because a timed-out release is left failed rather than pending, redeploying
+  upgrades over it and picks up the finished state.

--- a/deploy/aws-cdk/bin/lightdash.ts
+++ b/deploy/aws-cdk/bin/lightdash.ts
@@ -1,0 +1,22 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { resolveConfig } from '../lib/config';
+import { LightdashStack } from '../lib/lightdash-stack';
+
+const app = new cdk.App();
+const config = resolveConfig(app);
+
+new LightdashStack(app, 'LightdashStack', {
+  config,
+  env: {
+    account: config.account,
+    region: config.region,
+  },
+  description: 'Self-hosted Lightdash on Amazon EKS',
+  tags: {
+    Application: 'lightdash',
+    ManagedBy: 'aws-cdk',
+  },
+});
+
+app.synth();

--- a/deploy/aws-cdk/cdk.json
+++ b/deploy/aws-cdk/cdk.json
@@ -1,0 +1,14 @@
+{
+  "app": "npx ts-node --prefer-ts-exts bin/lightdash.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": ["README.md", "cdk*.json", "tsconfig.json", "package*.json", "node_modules", "cdk.out"]
+  },
+  "context": {
+    "@aws-cdk/aws-iam:minimizePolicies": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk/aws-ec2:launchTemplateDefaultUserData": true,
+    "@aws-cdk/aws-s3:createDefaultLoggingPolicy": true,
+    "@aws-cdk/core:target-partitions": ["aws"]
+  }
+}

--- a/deploy/aws-cdk/lib/config.ts
+++ b/deploy/aws-cdk/lib/config.ts
@@ -1,0 +1,248 @@
+import { Construct } from 'constructs';
+
+/**
+ * Every input to the deployment, resolved from CDK context.
+ *
+ * Context is used rather than environment variables so that `cdk synth`,
+ * `cdk diff` and `cdk deploy` all see the same values, and so that a team can
+ * commit its own defaults to cdk.context.json without touching this file.
+ */
+export interface LightdashConfig {
+  /** Deployment region. Falls back to the CLI or profile region. */
+  readonly region?: string;
+  /** Account to deploy into. Falls back to the CLI credentials. */
+  readonly account?: string;
+
+  /**
+   * Public hostname for the instance, for example lightdash.example.com.
+   *
+   * When unset the load balancer answers on any host and SITE_URL is left
+   * empty, which is enough to reach the login page but leaves emailed links
+   * pointing at the wrong origin. See the README for the two-pass workflow.
+   */
+  readonly hostname?: string;
+  /** ACM certificate for the load balancer. Requires hostname. */
+  readonly certificateArn?: string;
+  /**
+   * Accepts a load balancer that serves plain HTTP to the internet, which is
+   * what happens with no certificate. Required rather than assumed, because
+   * logins and session cookies would otherwise cross the internet in clear
+   * text without the operator ever choosing that.
+   */
+  readonly allowInsecureHttp: boolean;
+
+  readonly vpcCidr: string;
+  /**
+   * One NAT gateway is the default because two is the largest avoidable cost
+   * in this stack. Raise to the AZ count for production.
+   */
+  readonly natGateways: number;
+  readonly maxAzs: number;
+
+  readonly kubernetesVersion: string;
+  readonly nodeInstanceType: string;
+  readonly nodeDiskSizeGb: number;
+  readonly nodeMinSize: number;
+  readonly nodeMaxSize: number;
+  readonly nodeDesiredSize: number;
+
+  readonly dbInstanceType: string;
+  readonly dbAllocatedStorageGb: number;
+  readonly dbMaxAllocatedStorageGb: number;
+  readonly dbBackupRetentionDays: number;
+  /**
+   * Turns on RDS deletion protection. Off by default, because it makes
+   * `cdk destroy` fail at the database until a redeploy turns it off again,
+   * including the final snapshot that retainData asks for. It belongs here
+   * rather than in the console, where the next deploy would revert it.
+   */
+  readonly dbDeletionProtection: boolean;
+  /**
+   * Engine version. The major family on its own, for example 16, which RDS
+   * resolves to the latest minor it supports. A full version such as 16.14
+   * pins the minor at create time, but RDS removes old minors as they age, so
+   * a pinned default would eventually stop being deployable at all. Minor
+   * upgrades are applied in the maintenance window either way.
+   */
+  readonly postgresVersion: string;
+  /** Major version family the engine version belongs to, for example 16. */
+  readonly postgresMajorVersion: string;
+
+  readonly namespace: string;
+  readonly releaseName: string;
+  /**
+   * Version of the upstream lightdash chart to install. Pinned rather than
+   * floating so that a redeploy is reproducible.
+   */
+  readonly chartVersion: string;
+  readonly chartRepository: string;
+
+  /**
+   * When true, `cdk destroy` takes a final database snapshot and keeps the
+   * bucket and the secrets. Off by default because the primary audience is
+   * evaluating, and retained storage keeps billing after the operator believes
+   * they have torn everything down.
+   */
+  readonly retainData: boolean;
+
+  /** Principal granted cluster-admin, for example an SSO role ARN. */
+  readonly adminRoleArn?: string;
+}
+
+const DEFAULTS = {
+  allowInsecureHttp: false,
+  vpcCidr: '10.0.0.0/16',
+  natGateways: 1,
+  maxAzs: 2,
+  kubernetesVersion: '1.31',
+  nodeInstanceType: 't3.large',
+  nodeDiskSizeGb: 30,
+  nodeMinSize: 2,
+  nodeMaxSize: 4,
+  nodeDesiredSize: 2,
+  dbInstanceType: 't4g.micro',
+  dbAllocatedStorageGb: 20,
+  dbMaxAllocatedStorageGb: 100,
+  dbBackupRetentionDays: 7,
+  dbDeletionProtection: false,
+  postgresVersion: '16',
+  postgresMajorVersion: '16',
+  namespace: 'lightdash',
+  releaseName: 'lightdash',
+  chartVersion: '2.10.241',
+  chartRepository: 'https://lightdash.github.io/helm-charts',
+  retainData: false,
+} as const;
+
+function str(scope: Construct, key: string, fallback: string): string {
+  const value = scope.node.tryGetContext(key);
+  return value === undefined || value === '' ? fallback : String(value);
+}
+
+function optionalStr(scope: Construct, key: string): string | undefined {
+  const value = scope.node.tryGetContext(key);
+  return value === undefined || value === '' ? undefined : String(value);
+}
+
+function num(scope: Construct, key: string, fallback: number): number {
+  const value = scope.node.tryGetContext(key);
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`Context value ${key} must be a number, got "${value}"`);
+  }
+  return parsed;
+}
+
+function bool(scope: Construct, key: string, fallback: boolean): boolean {
+  const value = scope.node.tryGetContext(key);
+  if (value === undefined || value === '') {
+    return fallback;
+  }
+  // Context arriving from -c is always a string, so compare textually.
+  return value === true || String(value).toLowerCase() === 'true';
+}
+
+export function resolveConfig(scope: Construct): LightdashConfig {
+  const config: LightdashConfig = {
+    region: optionalStr(scope, 'region') ?? process.env.CDK_DEFAULT_REGION,
+    account: optionalStr(scope, 'account') ?? process.env.CDK_DEFAULT_ACCOUNT,
+
+    hostname: optionalStr(scope, 'hostname'),
+    certificateArn: optionalStr(scope, 'certificateArn'),
+    allowInsecureHttp: bool(scope, 'allowInsecureHttp', DEFAULTS.allowInsecureHttp),
+
+    vpcCidr: str(scope, 'vpcCidr', DEFAULTS.vpcCidr),
+    natGateways: num(scope, 'natGateways', DEFAULTS.natGateways),
+    maxAzs: num(scope, 'maxAzs', DEFAULTS.maxAzs),
+
+    kubernetesVersion: str(scope, 'kubernetesVersion', DEFAULTS.kubernetesVersion),
+    nodeInstanceType: str(scope, 'nodeInstanceType', DEFAULTS.nodeInstanceType),
+    nodeDiskSizeGb: num(scope, 'nodeDiskSizeGb', DEFAULTS.nodeDiskSizeGb),
+    nodeMinSize: num(scope, 'nodeMinSize', DEFAULTS.nodeMinSize),
+    nodeMaxSize: num(scope, 'nodeMaxSize', DEFAULTS.nodeMaxSize),
+    nodeDesiredSize: num(scope, 'nodeDesiredSize', DEFAULTS.nodeDesiredSize),
+
+    dbInstanceType: str(scope, 'dbInstanceType', DEFAULTS.dbInstanceType),
+    dbAllocatedStorageGb: num(scope, 'dbAllocatedStorageGb', DEFAULTS.dbAllocatedStorageGb),
+    dbMaxAllocatedStorageGb: num(
+      scope,
+      'dbMaxAllocatedStorageGb',
+      DEFAULTS.dbMaxAllocatedStorageGb,
+    ),
+    dbBackupRetentionDays: num(scope, 'dbBackupRetentionDays', DEFAULTS.dbBackupRetentionDays),
+    dbDeletionProtection: bool(scope, 'dbDeletionProtection', DEFAULTS.dbDeletionProtection),
+    postgresVersion: str(scope, 'postgresVersion', DEFAULTS.postgresVersion),
+    postgresMajorVersion: str(scope, 'postgresMajorVersion', DEFAULTS.postgresMajorVersion),
+
+    namespace: str(scope, 'namespace', DEFAULTS.namespace),
+    releaseName: str(scope, 'releaseName', DEFAULTS.releaseName),
+    chartVersion: str(scope, 'chartVersion', DEFAULTS.chartVersion),
+    chartRepository: str(scope, 'chartRepository', DEFAULTS.chartRepository),
+
+    retainData: bool(scope, 'retainData', DEFAULTS.retainData),
+    adminRoleArn: optionalStr(scope, 'adminRoleArn'),
+  };
+
+  validate(config);
+  return config;
+}
+
+/**
+ * Rejects at synth what the services would otherwise reject mid-deploy, after
+ * a cluster has been created and paid for.
+ */
+function validate(config: LightdashConfig): void {
+  // Sizes and counts are integers everywhere they are consumed, and Number()
+  // happily returns 1.5, which arrives at CloudFormation as an invalid
+  // property rather than a config error.
+  for (const [key, value, minimum] of [
+    ['natGateways', config.natGateways, 1],
+    ['maxAzs', config.maxAzs, 2],
+    ['nodeDiskSizeGb', config.nodeDiskSizeGb, 20],
+    ['nodeMinSize', config.nodeMinSize, 1],
+    ['nodeMaxSize', config.nodeMaxSize, 1],
+    ['nodeDesiredSize', config.nodeDesiredSize, 1],
+    ['dbAllocatedStorageGb', config.dbAllocatedStorageGb, 20],
+    ['dbMaxAllocatedStorageGb', config.dbMaxAllocatedStorageGb, 20],
+    ['dbBackupRetentionDays', config.dbBackupRetentionDays, 0],
+  ] as const) {
+    if (!Number.isInteger(value)) {
+      throw new Error(`${key} must be a whole number, got ${value}`);
+    }
+    if (value < minimum) {
+      throw new Error(`${key} must be at least ${minimum}, got ${value}`);
+    }
+  }
+
+  if (config.certificateArn && !config.hostname) {
+    throw new Error('certificateArn requires hostname, since the certificate must match a host');
+  }
+  if (!config.certificateArn && !config.allowInsecureHttp) {
+    throw new Error(
+      'Without certificateArn the load balancer is internet-facing and serves plain HTTP, ' +
+        'so logins cross the internet in clear text. Pass -c hostname and -c certificateArn ' +
+        'for TLS, or -c allowInsecureHttp=true to accept that for an evaluation.',
+    );
+  }
+  if (config.nodeDesiredSize < config.nodeMinSize || config.nodeDesiredSize > config.nodeMaxSize) {
+    throw new Error('nodeDesiredSize must fall between nodeMinSize and nodeMaxSize');
+  }
+  if (config.dbMaxAllocatedStorageGb < config.dbAllocatedStorageGb) {
+    throw new Error(
+      'dbMaxAllocatedStorageGb must be at least dbAllocatedStorageGb, since RDS storage ' +
+        'autoscaling only grows',
+    );
+  }
+  if (config.dbBackupRetentionDays > 35) {
+    throw new Error('dbBackupRetentionDays cannot exceed 35, the RDS maximum');
+  }
+  const major = config.postgresMajorVersion;
+  if (config.postgresVersion !== major && !config.postgresVersion.startsWith(`${major}.`)) {
+    throw new Error(
+      `postgresVersion ${config.postgresVersion} is not in major family ${major}`,
+    );
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/application.ts
+++ b/deploy/aws-cdk/lib/constructs/application.ts
@@ -1,0 +1,202 @@
+import { Duration } from 'aws-cdk-lib';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import * as rds from 'aws-cdk-lib/aws-rds';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import { LightdashConfig } from '../config';
+import {
+  APPLICATION_SECRET_NAME,
+  DATABASE_PASSWORD_KEY,
+  DATABASE_SECRET_NAME,
+} from './secret-sync';
+
+export interface ApplicationProps {
+  readonly config: LightdashConfig;
+  readonly cluster: eks.Cluster;
+  readonly namespaceManifest: eks.KubernetesManifest;
+  readonly bucket: s3.IBucket;
+  readonly database: rds.DatabaseInstance;
+  readonly databaseName: string;
+  readonly databaseUser: string;
+  readonly region: string;
+  /** Applied before the release, so the secrets exist when pods start. */
+  readonly dependencies: eks.KubernetesManifest[];
+}
+
+const SERVICE_ACCOUNT_NAME = 'lightdash';
+/** Readiness path the chart already uses, reused for the load balancer. */
+const HEALTH_CHECK_PATH = '/api/v1/health';
+
+/**
+ * Installs the upstream lightdash chart, unmodified, against the provisioned
+ * AWS resources.
+ *
+ * The chart is pulled from the published repository by version. It is never
+ * vendored or patched, so this deployment path stays valid as the chart is
+ * released independently.
+ */
+export class Application extends Construct {
+  public readonly serviceAccount: eks.ServiceAccount;
+  public readonly release: eks.HelmChart;
+
+  constructor(scope: Construct, id: string, props: ApplicationProps) {
+    super(scope, id);
+
+    const {
+      config,
+      cluster,
+      namespaceManifest,
+      bucket,
+      database,
+      databaseName,
+      databaseUser,
+      region,
+      dependencies,
+    } = props;
+
+    // IRSA, so the pods reach S3 with a scoped role instead of access keys
+    // held in a Secret. Lightdash omits explicit credentials when
+    // S3_ACCESS_KEY is unset and falls back to the AWS SDK chain, which picks
+    // up the projected web identity token.
+    this.serviceAccount = cluster.addServiceAccount('ServiceAccount', {
+      name: SERVICE_ACCOUNT_NAME,
+      namespace: config.namespace,
+    });
+    this.serviceAccount.node.addDependency(namespaceManifest);
+    bucket.grantReadWrite(this.serviceAccount);
+
+    const useTls = Boolean(config.certificateArn);
+    const siteUrl = config.hostname
+      ? `${useTls ? 'https' : 'http'}://${config.hostname}`
+      : '';
+
+    // Encrypts the database connection without verifying the server
+    // certificate. RDS PostgreSQL 15 and later default rds.force_ssl to 1, so
+    // an unencrypted connection is refused outright and this cannot be omitted.
+    //
+    // no-verify rather than require, which is not the libpq meaning of either.
+    // Lightdash connects through node-postgres, so require ends up in Node's
+    // TLS defaults and the chain is checked against the image's trust store,
+    // which has no Amazon RDS root. The result is that every start dies with
+    // "self-signed certificate in certificate chain" before the migrations run.
+    // See the README for moving to verify-full with the RDS CA bundle, which
+    // the chart supports through ssl.enabled.
+    const sslEnv = [{ name: 'PGSSLMODE', value: 'no-verify' }];
+
+    const values = {
+      // The chart's bundled PostgreSQL is replaced by RDS.
+      postgresql: { enabled: false },
+      externalDatabase: {
+        host: database.instanceEndpoint.hostname,
+        port: database.instanceEndpoint.port,
+        user: databaseUser,
+        database: databaseName,
+        existingSecret: DATABASE_SECRET_NAME,
+        secretKeys: { passwordKey: DATABASE_PASSWORD_KEY },
+      },
+
+      // envFrom on every pod. Supplies LIGHTDASH_SECRET, which otherwise
+      // defaults to the literal "changeme" from the chart's values.
+      existingSecret: APPLICATION_SECRET_NAME,
+
+      // existingSecret already wins in envFrom, but .Values.secrets separately
+      // decides whether the chart creates a Secret of its own. Left at its
+      // default it produces an unread Secret holding LIGHTDASH_SECRET=changeme.
+      // Nulling it keeps that value out of the cluster entirely.
+      secrets: null,
+
+      serviceAccount: {
+        create: false,
+        name: SERVICE_ACCOUNT_NAME,
+      },
+
+      configMap: {
+        PORT: '8080',
+        SITE_URL: siteUrl,
+        SECURE_COOKIES: useTls ? 'true' : 'false',
+        // The load balancer terminates the client connection, so the scheme
+        // is only visible through X-Forwarded-Proto.
+        TRUST_PROXY: 'true',
+      },
+
+      // Applied to the backend and to the worker.
+      extraEnv: [
+        ...sslEnv,
+        { name: 'S3_ENDPOINT', value: `https://s3.${region}.amazonaws.com` },
+        { name: 'S3_BUCKET', value: bucket.bucketName },
+        { name: 'S3_REGION', value: region },
+        // Pins credential resolution to the projected service account token
+        // rather than letting the SDK walk the whole chain, which would
+        // otherwise reach the node instance profile if IRSA were misconfigured
+        // and grant whatever the nodes can do.
+        { name: 'S3_USE_CREDENTIALS_FROM', value: 'token_file' },
+      ],
+
+      // Disabled, matching the chart default. With a single replica there is
+      // no migration lock race for it to solve, and as a pre-install hook it
+      // would run before External Secrets has produced the password. The env
+      // is set so that enabling it later does not fail on SSL.
+      migrationJob: {
+        enabled: false,
+        extraEnv: sslEnv,
+      },
+
+      ingress: {
+        enabled: true,
+        className: 'alb',
+        annotations: {
+          'alb.ingress.kubernetes.io/scheme': 'internet-facing',
+          // Routes to pod IPs directly, which the VPC CNI makes routable.
+          'alb.ingress.kubernetes.io/target-type': 'ip',
+          'alb.ingress.kubernetes.io/healthcheck-path': HEALTH_CHECK_PATH,
+          'alb.ingress.kubernetes.io/listen-ports': useTls
+            ? '[{"HTTP":80},{"HTTPS":443}]'
+            : '[{"HTTP":80}]',
+          ...(useTls
+            ? {
+                'alb.ingress.kubernetes.io/certificate-arn': config.certificateArn!,
+                'alb.ingress.kubernetes.io/ssl-redirect': '443',
+              }
+            : {}),
+        },
+        hosts: [
+          {
+            // An empty host matches any name, which is what makes the load
+            // balancer's own DNS name usable before a domain exists.
+            host: config.hostname ?? '',
+            paths: [{ path: '/', pathType: 'Prefix' }],
+          },
+        ],
+      },
+    };
+
+    this.release = cluster.addHelmChart('Lightdash', {
+      repository: config.chartRepository,
+      chart: 'lightdash',
+      release: config.releaseName,
+      namespace: config.namespace,
+      version: config.chartVersion,
+      wait: true,
+      // Deliberately under the 15 minutes CDK gives its kubectl provider
+      // Lambda. At exactly 15 the Lambda is killed while helm is still
+      // waiting, CloudFormation retries, and the retry finds the release
+      // pending-install and fails with "another operation is in progress",
+      // which no redeploy clears. Losing the race on purpose leaves a failed
+      // release instead, which the next deploy upgrades over.
+      timeout: Duration.minutes(13),
+      values,
+    });
+
+    this.release.node.addDependency(namespaceManifest, this.serviceAccount, ...dependencies);
+
+    // Ordering that matters on the way down rather than up. The controller puts
+    // a finalizer on the Ingress it provisions an ALB for, and only the
+    // controller removes it. Without this the two can be torn down in either
+    // order, and if the controller goes first the Ingress keeps its finalizer,
+    // the namespace never leaves Terminating, the load balancer is left behind,
+    // and destroy stops with no way forward but manual surgery.
+    if (cluster.albController) {
+      this.release.node.addDependency(cluster.albController);
+    }
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/cluster.ts
+++ b/deploy/aws-cdk/lib/constructs/cluster.ts
@@ -1,0 +1,89 @@
+import { KubectlV31Layer } from '@aws-cdk/lambda-layer-kubectl-v31';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import { Construct } from 'constructs';
+import { LightdashConfig } from '../config';
+
+export interface ClusterProps {
+  readonly config: LightdashConfig;
+  readonly vpc: ec2.IVpc;
+}
+
+/**
+ * Load balancer controller version. Pinned so that a redeploy months later
+ * installs the same controller instead of whatever is current.
+ *
+ * A named version is used rather than AlbControllerVersion.of() because CDK
+ * bundles the matching IAM policy only for versions it knows, and requires the
+ * caller to supply the whole policy document for any other.
+ */
+const ALB_CONTROLLER_VERSION = eks.AlbControllerVersion.V2_13_4;
+
+/**
+ * EKS cluster, its managed node group, and the AWS Load Balancer Controller.
+ *
+ * The kubectl Lambda layer is pinned to a Kubernetes minor version by its
+ * package name, so raising `kubernetesVersion` past 1.31 also means depending
+ * on the matching @aws-cdk/lambda-layer-kubectl-vNN package and importing it
+ * here. There is no way to make that automatic.
+ */
+export class Cluster extends Construct {
+  public readonly cluster: eks.Cluster;
+  public readonly nodegroup: eks.Nodegroup;
+
+  constructor(scope: Construct, id: string, props: ClusterProps) {
+    super(scope, id);
+
+    const { config, vpc } = props;
+
+    this.cluster = new eks.Cluster(this, 'Cluster', {
+      version: eks.KubernetesVersion.of(config.kubernetesVersion),
+      kubectlLayer: new KubectlV31Layer(this, 'KubectlLayer'),
+      vpc,
+      vpcSubnets: [{ subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS }],
+      // Capacity is added below as a managed node group, which supports
+      // rolling AMI updates that the default self-managed ASG does not.
+      defaultCapacity: 0,
+      endpointAccess: eks.EndpointAccess.PUBLIC_AND_PRIVATE,
+      // Access entries as well as aws-auth. Under CONFIG_MAP alone the only
+      // principal that can reach the API server is the role CDK created the
+      // cluster with, and nobody can be added without already holding access,
+      // so the operator who ran the deploy cannot run kubectl at all. With the
+      // API mode on they can grant themselves an access entry from IAM. See the
+      // README.
+      authenticationMode: eks.AuthenticationMode.API_AND_CONFIG_MAP,
+      albController: { version: ALB_CONTROLLER_VERSION },
+      clusterLogging: [
+        eks.ClusterLoggingTypes.API,
+        eks.ClusterLoggingTypes.AUDIT,
+        eks.ClusterLoggingTypes.AUTHENTICATOR,
+      ],
+    });
+
+    this.nodegroup = this.cluster.addNodegroupCapacity('Nodes', {
+      instanceTypes: [new ec2.InstanceType(config.nodeInstanceType)],
+      minSize: config.nodeMinSize,
+      maxSize: config.nodeMaxSize,
+      desiredSize: config.nodeDesiredSize,
+      diskSize: config.nodeDiskSizeGb,
+      subnets: { subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS },
+    });
+
+    // The controller's Helm release waits for its pods to become ready, and
+    // with defaultCapacity at 0 there is nothing to schedule on until the node
+    // group exists. Without this ordering the first deploy can time out.
+    this.cluster.albController?.node.addDependency(this.nodegroup);
+
+    if (config.adminRoleArn) {
+      // An access entry rather than an aws-auth mapping, because aws-auth is
+      // edited by the kubectl provider from inside the cluster and an access
+      // entry is an EKS API call, so it still lands if the cluster is
+      // unreachable.
+      this.cluster.grantAccess('AdminAccess', config.adminRoleArn, [
+        eks.AccessPolicy.fromAccessPolicyName('AmazonEKSClusterAdminPolicy', {
+          accessScopeType: eks.AccessScopeType.CLUSTER,
+        }),
+      ]);
+    }
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/database.ts
+++ b/deploy/aws-cdk/lib/constructs/database.ts
@@ -1,0 +1,87 @@
+import { Annotations, Duration, RemovalPolicy } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import * as rds from 'aws-cdk-lib/aws-rds';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+import { LightdashConfig } from '../config';
+
+export interface DatabaseProps {
+  readonly config: LightdashConfig;
+  readonly vpc: ec2.IVpc;
+}
+
+/** Database name and user created on the instance. */
+const DATABASE_NAME = 'lightdash';
+const DATABASE_USER = 'lightdash';
+
+/**
+ * RDS PostgreSQL for the Lightdash metadata database, replacing the chart's
+ * bundled postgresql subchart.
+ *
+ * The password is generated into Secrets Manager and never leaves it: it
+ * reaches the cluster through External Secrets, so no plaintext credential is
+ * present in the CloudFormation template, in CDK context, or in Helm values.
+ */
+export class Database extends Construct {
+  public readonly instance: rds.DatabaseInstance;
+  public readonly secret: secretsmanager.ISecret;
+  public readonly databaseName = DATABASE_NAME;
+  public readonly databaseUser = DATABASE_USER;
+
+  constructor(scope: Construct, id: string, props: DatabaseProps) {
+    super(scope, id);
+
+    const { config, vpc } = props;
+    const retain = config.retainData;
+
+    this.instance = new rds.DatabaseInstance(this, 'Instance', {
+      engine: rds.DatabaseInstanceEngine.postgres({
+        // Built from config rather than a PostgresEngineVersion constant so
+        // that upgrading the engine does not require a new aws-cdk-lib.
+        version: rds.PostgresEngineVersion.of(
+          config.postgresVersion,
+          config.postgresMajorVersion,
+        ),
+      }),
+      instanceType: new ec2.InstanceType(config.dbInstanceType),
+      vpc,
+      vpcSubnets: { subnetType: ec2.SubnetType.PRIVATE_ISOLATED },
+      publiclyAccessible: false,
+      multiAz: false,
+      allocatedStorage: config.dbAllocatedStorageGb,
+      maxAllocatedStorage: config.dbMaxAllocatedStorageGb,
+      storageEncrypted: true,
+      databaseName: DATABASE_NAME,
+      credentials: rds.Credentials.fromGeneratedSecret(DATABASE_USER, {
+        // The default generator includes characters that break libpq
+        // connection strings and Kubernetes env interpolation.
+        excludeCharacters: ' %+~`#$&*()|[]{}:;<>?!\'/"\\@',
+      }),
+      backupRetention: Duration.days(config.dbBackupRetentionDays),
+      deleteAutomatedBackups: !retain,
+      // Off by default, and not tied to retainData. Protection makes RDS
+      // reject the delete that either removal policy asks for, so pairing the
+      // two would leave the stack in DELETE_FAILED with no snapshot taken,
+      // which is the opposite of what retainData promises.
+      deletionProtection: config.dbDeletionProtection,
+      removalPolicy: retain ? RemovalPolicy.SNAPSHOT : RemovalPolicy.DESTROY,
+    });
+
+    if (config.dbDeletionProtection) {
+      Annotations.of(this).addWarning(
+        'dbDeletionProtection is on, so `cdk destroy` will fail at the database. Redeploy ' +
+          'with -c dbDeletionProtection=false first, then destroy.',
+      );
+    }
+
+    if (!this.instance.secret) {
+      throw new Error('Expected fromGeneratedSecret to attach a secret to the instance');
+    }
+    this.secret = this.instance.secret;
+  }
+
+  /** Allows the given peer to reach PostgreSQL. */
+  public allowFrom(peer: ec2.IConnectable, description: string): void {
+    this.instance.connections.allowDefaultPortFrom(peer, description);
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/network.ts
+++ b/deploy/aws-cdk/lib/constructs/network.ts
@@ -1,0 +1,58 @@
+import { Tags } from 'aws-cdk-lib';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Construct } from 'constructs';
+import { LightdashConfig } from '../config';
+
+export interface NetworkProps {
+  readonly config: LightdashConfig;
+}
+
+/**
+ * VPC with public and private subnets across at least two availability zones.
+ *
+ * Nodes and the database sit in the private subnets; only load balancers are
+ * placed publicly.
+ */
+export class Network extends Construct {
+  public readonly vpc: ec2.Vpc;
+
+  constructor(scope: Construct, id: string, props: NetworkProps) {
+    super(scope, id);
+
+    const { config } = props;
+
+    this.vpc = new ec2.Vpc(this, 'Vpc', {
+      ipAddresses: ec2.IpAddresses.cidr(config.vpcCidr),
+      maxAzs: config.maxAzs,
+      natGateways: config.natGateways,
+      subnetConfiguration: [
+        {
+          name: 'public',
+          subnetType: ec2.SubnetType.PUBLIC,
+          cidrMask: 24,
+        },
+        {
+          name: 'private',
+          subnetType: ec2.SubnetType.PRIVATE_WITH_EGRESS,
+          cidrMask: 24,
+        },
+        {
+          name: 'isolated',
+          subnetType: ec2.SubnetType.PRIVATE_ISOLATED,
+          cidrMask: 24,
+        },
+      ],
+    });
+
+    // The load balancer controller discovers subnets by tag. Without these it
+    // reports "unable to discover at least one subnet" and no Ingress is ever
+    // provisioned, which is the most common failure in an otherwise healthy
+    // cluster. CDK does not add them.
+    this.vpc.publicSubnets.forEach((subnet) => {
+      Tags.of(subnet).add('kubernetes.io/role/elb', '1');
+    });
+    this.vpc.privateSubnets.forEach((subnet) => {
+      Tags.of(subnet).add('kubernetes.io/role/internal-elb', '1');
+    });
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/secret-sync.ts
+++ b/deploy/aws-cdk/lib/constructs/secret-sync.ts
@@ -1,0 +1,170 @@
+import { Duration } from 'aws-cdk-lib';
+import * as eks from 'aws-cdk-lib/aws-eks';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+
+export interface SecretSyncProps {
+  readonly cluster: eks.Cluster;
+  /** The operator needs somewhere to run before its install can complete. */
+  readonly nodegroup: eks.Nodegroup;
+  /** Namespace the Lightdash release runs in. Must already exist. */
+  readonly appNamespace: string;
+  /** Applied before anything targeting appNamespace. */
+  readonly appNamespaceManifest: eks.KubernetesManifest;
+  readonly databaseSecret: secretsmanager.ISecret;
+  readonly applicationSecret: secretsmanager.ISecret;
+  readonly region: string;
+}
+
+const ESO_NAMESPACE = 'external-secrets';
+const ESO_SERVICE_ACCOUNT = 'external-secrets';
+/** Pinned so a redeploy installs the same operator. */
+const ESO_CHART_VERSION = '0.10.4';
+const SECRET_STORE_NAME = 'aws-secrets-manager';
+
+/** Kubernetes Secret names this construct produces. */
+export const DATABASE_SECRET_NAME = 'lightdash-database';
+export const DATABASE_PASSWORD_KEY = 'postgresql-password';
+export const APPLICATION_SECRET_NAME = 'lightdash-application';
+export const LIGHTDASH_SECRET_KEY = 'LIGHTDASH_SECRET';
+
+/**
+ * Copies credentials from Secrets Manager into Kubernetes Secrets using the
+ * External Secrets Operator.
+ *
+ * The alternative, passing the password straight into Helm values, would place
+ * the plaintext in the CloudFormation template and in the kubectl provider's
+ * event payload. Reading it inside the cluster instead means the only copies
+ * are in Secrets Manager and in etcd. The operator also refreshes on its own,
+ * so rotating the RDS secret does not require a redeploy.
+ */
+export class SecretSync extends Construct {
+  /** Depend on this before scheduling any pod that consumes the secrets. */
+  public readonly manifests: eks.KubernetesManifest[];
+
+  constructor(scope: Construct, id: string, props: SecretSyncProps) {
+    super(scope, id);
+
+    const {
+      cluster,
+      nodegroup,
+      appNamespace,
+      appNamespaceManifest,
+      databaseSecret,
+      applicationSecret,
+      region,
+    } = props;
+
+    const namespace = cluster.addManifest('EsoNamespace', {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: ESO_NAMESPACE },
+    });
+
+    // The controller reads Secrets Manager with this identity. CDK builds the
+    // OIDC trust policy, which needs the cluster issuer inside a condition
+    // key and cannot be written by hand in CloudFormation.
+    const serviceAccount = cluster.addServiceAccount('EsoServiceAccount', {
+      name: ESO_SERVICE_ACCOUNT,
+      namespace: ESO_NAMESPACE,
+    });
+    serviceAccount.node.addDependency(namespace);
+
+    databaseSecret.grantRead(serviceAccount);
+    applicationSecret.grantRead(serviceAccount);
+
+    const operator = cluster.addHelmChart('ExternalSecrets', {
+      repository: 'https://charts.external-secrets.io',
+      chart: 'external-secrets',
+      release: 'external-secrets',
+      namespace: ESO_NAMESPACE,
+      version: ESO_CHART_VERSION,
+      // The CRDs and the validating webhook must both be live before any
+      // SecretStore or ExternalSecret is applied, so block here rather than
+      // letting the next manifest fail on an unknown kind.
+      wait: true,
+      timeout: Duration.minutes(10),
+      values: {
+        installCRDs: true,
+        serviceAccount: {
+          create: false,
+          name: ESO_SERVICE_ACCOUNT,
+        },
+      },
+    });
+    // The node group is created in parallel with the cluster's kubectl
+    // provider, so without this the install can start before any node has
+    // registered, leave three deployments pending, and time out.
+    operator.node.addDependency(serviceAccount, nodegroup);
+
+    // Namespaced rather than a ClusterSecretStore. A cluster-scoped store can
+    // be named by an ExternalSecret in any namespace, so a workload with no
+    // access to this one could still ask the operator to fetch the database
+    // password on its behalf. Scoping the store to the release namespace means
+    // only something already inside it can do that.
+    const secretStore = cluster.addManifest('SecretStore', {
+      apiVersion: 'external-secrets.io/v1beta1',
+      kind: 'SecretStore',
+      metadata: { name: SECRET_STORE_NAME, namespace: appNamespace },
+      spec: {
+        provider: {
+          aws: {
+            service: 'SecretsManager',
+            region,
+            // auth is omitted on purpose: the controller then uses its pod
+            // identity, which is the IRSA role above.
+          },
+        },
+      },
+    });
+    secretStore.node.addDependency(operator, appNamespaceManifest);
+
+    const databaseExternalSecret = cluster.addManifest('DatabaseExternalSecret', {
+      apiVersion: 'external-secrets.io/v1beta1',
+      kind: 'ExternalSecret',
+      metadata: { name: DATABASE_SECRET_NAME, namespace: appNamespace },
+      spec: {
+        refreshInterval: '1h',
+        secretStoreRef: { name: SECRET_STORE_NAME, kind: 'SecretStore' },
+        target: { name: DATABASE_SECRET_NAME, creationPolicy: 'Owner' },
+        data: [
+          {
+            // The chart reads the password under this key, set by
+            // externalDatabase.secretKeys.passwordKey.
+            secretKey: DATABASE_PASSWORD_KEY,
+            remoteRef: {
+              key: databaseSecret.secretArn,
+              property: 'password',
+            },
+          },
+        ],
+      },
+    });
+    databaseExternalSecret.node.addDependency(secretStore, appNamespaceManifest);
+
+    const applicationExternalSecret = cluster.addManifest('ApplicationExternalSecret', {
+      apiVersion: 'external-secrets.io/v1beta1',
+      kind: 'ExternalSecret',
+      metadata: { name: APPLICATION_SECRET_NAME, namespace: appNamespace },
+      spec: {
+        refreshInterval: '1h',
+        secretStoreRef: { name: SECRET_STORE_NAME, kind: 'SecretStore' },
+        // envFrom injects every key in this Secret, so it holds only values
+        // Lightdash expects to see as environment variables.
+        target: { name: APPLICATION_SECRET_NAME, creationPolicy: 'Owner' },
+        data: [
+          {
+            secretKey: LIGHTDASH_SECRET_KEY,
+            remoteRef: {
+              key: applicationSecret.secretArn,
+              property: LIGHTDASH_SECRET_KEY,
+            },
+          },
+        ],
+      },
+    });
+    applicationExternalSecret.node.addDependency(secretStore, appNamespaceManifest);
+
+    this.manifests = [databaseExternalSecret, applicationExternalSecret];
+  }
+}

--- a/deploy/aws-cdk/lib/constructs/storage.ts
+++ b/deploy/aws-cdk/lib/constructs/storage.ts
@@ -1,0 +1,53 @@
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+import { LightdashConfig } from '../config';
+
+export interface StorageProps {
+  readonly config: LightdashConfig;
+}
+
+/**
+ * Object storage for Lightdash results, charts and uploaded images.
+ *
+ * Lightdash requires S3-compatible storage: parseBaseS3Config throws unless
+ * S3_ENDPOINT, S3_BUCKET and S3_REGION are all set, so this bucket is not
+ * optional for a working instance.
+ */
+export class Storage extends Construct {
+  public readonly bucket: s3.Bucket;
+
+  constructor(scope: Construct, id: string, props: StorageProps) {
+    super(scope, id);
+
+    const { config } = props;
+    const retain = config.retainData;
+
+    this.bucket = new s3.Bucket(this, 'Bucket', {
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      enforceSSL: true,
+      removalPolicy: retain ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+      // Without this, destroying a non-empty bucket fails and leaves the stack
+      // in DELETE_FAILED.
+      autoDeleteObjects: !retain,
+      lifecycleRules: [
+        {
+          // Multipart uploads that never completed are billed but unreachable.
+          abortIncompleteMultipartUploadAfter: Duration.days(7),
+        },
+      ],
+      // Lightdash mints presigned PUT URLs that the browser uploads to
+      // directly, so the browser origin must be allowed at the bucket.
+      cors: [
+        {
+          allowedMethods: [s3.HttpMethods.GET, s3.HttpMethods.PUT, s3.HttpMethods.HEAD],
+          allowedOrigins: config.hostname ? [`https://${config.hostname}`] : ['*'],
+          allowedHeaders: ['*'],
+          exposedHeaders: ['ETag'],
+          maxAge: 3000,
+        },
+      ],
+    });
+  }
+}

--- a/deploy/aws-cdk/lib/lightdash-stack.ts
+++ b/deploy/aws-cdk/lib/lightdash-stack.ts
@@ -1,0 +1,123 @@
+import { CfnOutput, RemovalPolicy, Stack, StackProps } from 'aws-cdk-lib';
+import * as secretsmanager from 'aws-cdk-lib/aws-secretsmanager';
+import { Construct } from 'constructs';
+import { LightdashConfig } from './config';
+import { Application } from './constructs/application';
+import { Cluster } from './constructs/cluster';
+import { Database } from './constructs/database';
+import { Network } from './constructs/network';
+import { LIGHTDASH_SECRET_KEY, SecretSync } from './constructs/secret-sync';
+import { Storage } from './constructs/storage';
+
+export interface LightdashStackProps extends StackProps {
+  readonly config: LightdashConfig;
+}
+
+/**
+ * Everything the deployment creates, in one stack.
+ *
+ * One stack rather than several because the alternative means exporting a
+ * security group and a VPC across stack boundaries, and CloudFormation then
+ * refuses to update an export while the consuming stack references it. That
+ * turns routine changes into manual export surgery, which is a poor trade for
+ * a deployment an operator runs end to end.
+ */
+export class LightdashStack extends Stack {
+  constructor(scope: Construct, id: string, props: LightdashStackProps) {
+    super(scope, id, props);
+
+    const { config } = props;
+    const retain = config.retainData;
+
+    const network = new Network(this, 'Network', { config });
+
+    const storage = new Storage(this, 'Storage', { config });
+
+    const database = new Database(this, 'Database', {
+      config,
+      vpc: network.vpc,
+    });
+
+    // Signs session cookies and encrypts stored warehouse credentials, so
+    // losing it invalidates every saved connection. Generated here so that no
+    // human ever sees it and the chart's "changeme" default is never used.
+    const applicationSecret = new secretsmanager.Secret(this, 'ApplicationSecret', {
+      description: 'Lightdash LIGHTDASH_SECRET',
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({}),
+        generateStringKey: LIGHTDASH_SECRET_KEY,
+        passwordLength: 64,
+        excludePunctuation: true,
+      },
+      removalPolicy: retain ? RemovalPolicy.RETAIN : RemovalPolicy.DESTROY,
+    });
+
+    const cluster = new Cluster(this, 'Compute', {
+      config,
+      vpc: network.vpc,
+    });
+
+    // Managed node groups attach the cluster security group, so this is what
+    // opens PostgreSQL to the pods.
+    database.allowFrom(cluster.cluster, 'Lightdash pods on EKS');
+
+    const namespaceManifest = cluster.cluster.addManifest('AppNamespace', {
+      apiVersion: 'v1',
+      kind: 'Namespace',
+      metadata: { name: config.namespace },
+    });
+    // Deleting a namespace waits for every pod in it to terminate, and a pod
+    // whose node has already gone never reports that it has. Depending on the
+    // node group puts the namespace ahead of it on the way down.
+    namespaceManifest.node.addDependency(cluster.nodegroup);
+
+    const secretSync = new SecretSync(this, 'SecretSync', {
+      cluster: cluster.cluster,
+      nodegroup: cluster.nodegroup,
+      appNamespace: config.namespace,
+      appNamespaceManifest: namespaceManifest,
+      databaseSecret: database.secret,
+      applicationSecret,
+      region: this.region,
+    });
+
+    new Application(this, 'Application', {
+      config,
+      cluster: cluster.cluster,
+      namespaceManifest,
+      bucket: storage.bucket,
+      database: database.instance,
+      databaseName: database.databaseName,
+      databaseUser: database.databaseUser,
+      region: this.region,
+      dependencies: secretSync.manifests,
+    });
+
+    new CfnOutput(this, 'ClusterName', {
+      value: cluster.cluster.clusterName,
+    });
+
+    new CfnOutput(this, 'KubeconfigCommand', {
+      description: 'Run this to point kubectl at the new cluster',
+      value: `aws eks update-kubeconfig --region ${this.region} --name ${cluster.cluster.clusterName}`,
+    });
+
+    new CfnOutput(this, 'IngressAddressCommand', {
+      description: 'The load balancer takes a few minutes to appear after the release',
+      value: `kubectl -n ${config.namespace} get ingress ${config.releaseName} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'`,
+    });
+
+    new CfnOutput(this, 'DatabaseEndpoint', {
+      value: database.instance.instanceEndpoint.hostname,
+    });
+
+    new CfnOutput(this, 'StorageBucket', {
+      value: storage.bucket.bucketName,
+    });
+
+    new CfnOutput(this, 'DatabaseSecretArn', {
+      description: 'Read the password with: aws secretsmanager get-secret-value --secret-id',
+      value: database.secret.secretArn,
+    });
+  }
+}

--- a/deploy/aws-cdk/package-lock.json
+++ b/deploy/aws-cdk/package-lock.json
@@ -1,0 +1,533 @@
+{
+  "name": "lightdash-aws-cdk",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "lightdash-aws-cdk",
+      "version": "0.1.0",
+      "license": "SEE LICENSE IN REPOSITORY ROOT",
+      "dependencies": {
+        "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.0",
+        "aws-cdk-lib": "^2.170.0",
+        "constructs": "^10.3.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0",
+        "aws-cdk": "^2.170.0",
+        "ts-node": "^10.9.2",
+        "typescript": "~5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@aws-cdk/asset-awscli-v1": {
+      "version": "2.2.292",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.292.tgz",
+      "integrity": "sha512-d4aMFsAFj19FtxVyw8IzlUKv5Zu4sIvgnEjI2IU6IWBJgVbJ4aFnadANqYa+6MwB1CQbGOg0jh8WE77M+Nb/9A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/asset-node-proxy-agent-v6": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v6/-/asset-node-proxy-agent-v6-2.1.2.tgz",
+      "integrity": "sha512-pDiuqH+qY3zM9lhhLjbKJ1tnKOHzQ2V4Wr/3qsxyKeKAkuPMI/BVGvZG1PbrikUw949cGVTfVEt4ETKKYnrj0Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema": {
+      "version": "54.18.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/cloud-assembly-schema/-/cloud-assembly-schema-54.18.0.tgz",
+      "integrity": "sha512-KceoGMrKbXp3qigQ8y67yq3Cd1k43GOw+E4KMf/MbDbRGyZEkfdLihhCD7obXvN5f1cKemZECFj+klLEoo1biA==",
+      "bundleDependencies": [
+        "jsonschema",
+        "semver"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.5"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@aws-cdk/cloud-assembly-schema/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@aws-cdk/lambda-layer-kubectl-v31": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/lambda-layer-kubectl-v31/-/lambda-layer-kubectl-v31-2.1.0.tgz",
+      "integrity": "sha512-ZO3nysb3X3zly10B91vTNXyeAxFPAsYVoKJLXxRTt7PRMhiD7W5TLLd/X/m6UZRbmtH623goi2HVSCAUhNFIuA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "aws-cdk-lib": "^2.94.0",
+        "constructs": "^10.0.5"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/aws-cdk": {
+      "version": "2.1136.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1136.0.tgz",
+      "integrity": "sha512-n6kCL9R9uuvb7WXEwiSs3rYGwnTy9AHHmxOT5Pj5/++E4PYz2bLDXIxzoiOMIj5maoyC52PTe/0GezFV+O0ILQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "cdk": "bin/cdk"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib": {
+      "version": "2.265.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.265.0.tgz",
+      "integrity": "sha512-Ur96d/ZW+gqAW4XtqKQp//D9O/jQvyRoXhAqoHGybpV03qjckGIQcLcGkLV68+jv03TX/rOXHCsa2IEFcCXa4w==",
+      "bundleDependencies": [
+        "@aws/cloudformation-validate",
+        "@balena/dockerignore",
+        "@aws-cdk/cloud-assembly-api",
+        "case",
+        "fs-extra",
+        "ignore",
+        "jsonschema",
+        "minimatch",
+        "punycode",
+        "semver",
+        "yaml",
+        "mime-types"
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-cdk/asset-awscli-v1": "2.2.292",
+        "@aws-cdk/asset-node-proxy-agent-v6": "^2.1.2",
+        "@aws-cdk/cloud-assembly-api": "^2.2.6",
+        "@aws-cdk/cloud-assembly-schema": "^54.11.0",
+        "@aws/cloudformation-validate": "1.7.0-beta",
+        "@balena/dockerignore": "^1.0.2",
+        "case": "1.6.3",
+        "fs-extra": "^11.3.6",
+        "ignore": "^5.3.2",
+        "jsonschema": "^1.5.0",
+        "mime-types": "^2.1.35",
+        "minimatch": "^10.2.5",
+        "punycode": "^2.3.1",
+        "semver": "^7.8.5",
+        "yaml": "1.10.3"
+      },
+      "engines": {
+        "node": ">= 20.0.0"
+      },
+      "peerDependencies": {
+        "constructs": "^10.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws-cdk/cloud-assembly-api": {
+      "version": "2.2.6",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jsonschema": "^1.5.0",
+        "semver": "^7.8.4"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "peerDependencies": {
+        "@aws-cdk/cloud-assembly-schema": ">=54.5.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@aws/cloudformation-validate": {
+      "version": "1.7.0-beta",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/@balena/dockerignore": {
+      "version": "1.0.2",
+      "inBundle": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/aws-cdk-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/case": {
+      "version": "1.6.3",
+      "inBundle": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/fs-extra": {
+      "version": "11.3.6",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/aws-cdk-lib/node_modules/ignore": {
+      "version": "5.3.2",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/jsonschema": {
+      "version": "1.5.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-db": {
+      "version": "1.52.0",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/mime-types": {
+      "version": "2.1.35",
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "inBundle": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/punycode": {
+      "version": "2.3.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aws-cdk-lib/node_modules/yaml": {
+      "version": "1.10.3",
+      "inBundle": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/constructs": {
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.8.1.tgz",
+      "integrity": "sha512-98yGXYyhePqPYh3cYu8nzBERmAhC0DONe3UD03okK0nehZ7hYP4wgZuf02a04+uOWxnTJ5Rpp5m0GRNpwyLGGA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    }
+  }
+}

--- a/deploy/aws-cdk/package.json
+++ b/deploy/aws-cdk/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "lightdash-aws-cdk",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Optional AWS CDK deployment for self-hosted Lightdash on Amazon EKS",
+  "license": "SEE LICENSE IN REPOSITORY ROOT",
+  "scripts": {
+    "build": "tsc",
+    "watch": "tsc --watch",
+    "synth": "cdk synth",
+    "diff": "cdk diff",
+    "deploy": "cdk deploy",
+    "destroy": "cdk destroy"
+  },
+  "dependencies": {
+    "@aws-cdk/lambda-layer-kubectl-v31": "^2.0.0",
+    "aws-cdk-lib": "^2.170.0",
+    "constructs": "^10.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "aws-cdk": "^2.170.0",
+    "ts-node": "^10.9.2",
+    "typescript": "~5.6.3"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/deploy/aws-cdk/tsconfig.json
+++ b/deploy/aws-cdk/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "lib": ["ES2022"],
+    "declaration": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": false,
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "strictPropertyInitialization": false,
+    "typeRoots": ["./node_modules/@types"]
+  },
+  "include": ["bin/**/*.ts", "lib/**/*.ts"],
+  "exclude": ["node_modules", "cdk.out"]
+}

--- a/docs/aws-eks-cdk-install.md
+++ b/docs/aws-eks-cdk-install.md
@@ -1,0 +1,143 @@
+# Lightdash on Amazon EKS with AWS CDK: install guide
+
+This guide provisions AWS infrastructure for a self-hosted Lightdash instance and installs
+the Lightdash Helm chart onto it, using the AWS CDK project in
+[`deploy/aws-cdk`](../deploy/aws-cdk).
+
+Use this path if you have an AWS account and no Kubernetes cluster. If you already have a
+cluster, install the chart directly and skip this guide: see the
+[chart README](../charts/lightdash/README.md). The chart is identical either way, and this
+project does not modify it.
+
+For a full list of context options, resources created, and cost, see the
+[project README](../deploy/aws-cdk/README.md).
+
+## Prerequisites
+
+- Node.js 20 or newer. The repository's `flake.nix` provides `nodejs_20`.
+- AWS credentials in your environment with permission to create VPC, EKS, RDS, S3, IAM and
+  Secrets Manager resources.
+- The CDK bootstrapped once per account and region.
+- [`kubectl`](https://kubernetes.io/docs/tasks/tools/) to inspect the result. Not required
+  to deploy.
+
+Expect around 260 USD per month at the defaults in `us-east-1`, of which 73 USD is the EKS
+control plane alone. This is not a free-tier deployment.
+
+## 1. Install and review
+
+```bash
+cd deploy/aws-cdk
+npm install
+npx cdk synth
+```
+
+`cdk synth` writes CloudFormation to `cdk.out` and creates nothing. Read it before
+deploying.
+
+## 2. Bootstrap the account and region
+
+Once per account and region:
+
+```bash
+npx cdk bootstrap aws://111122223333/us-east-1
+```
+
+## 3. Deploy
+
+With a domain and an ACM certificate, which is what you want for real use:
+
+```bash
+npx cdk deploy \
+  -c hostname=lightdash.example.com \
+  -c certificateArn=arn:aws:acm:us-east-1:111122223333:certificate/abcd1234
+```
+
+Without a domain, for evaluation only. The load balancer is reachable from the internet and
+serves plain HTTP, so logins and session cookies are not encrypted, and you have to say so
+to get it:
+
+```bash
+npx cdk deploy -c allowInsecureHttp=true
+```
+
+The first deploy takes 25 to 35 minutes. Most of that is the EKS control plane and the RDS
+instance.
+
+## 4. Reach the instance
+
+The stack prints the two commands you need. Point `kubectl` at the new cluster:
+
+```bash
+aws eks update-kubeconfig --region us-east-1 --name CLUSTER_NAME
+```
+
+If that reports `You must be logged in to the server`, your credentials have no entry on the
+cluster yet. Creating a cluster does not grant its creator CLI access. Add yourself, using
+the role ARN rather than the `assumed-role` ARN that `aws sts get-caller-identity` prints:
+
+```bash
+aws eks create-access-entry --cluster-name CLUSTER_NAME --principal-arn YOUR_ROLE_ARN
+aws eks associate-access-policy --cluster-name CLUSTER_NAME --principal-arn YOUR_ROLE_ARN \
+  --policy-arn arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy \
+  --access-scope type=cluster
+```
+
+Passing `-c adminRoleArn=YOUR_ROLE_ARN` at deploy time does the same thing up front.
+
+Then read the load balancer address off the Ingress. It appears two to three minutes after
+the release finishes, because the load balancer controller provisions it asynchronously:
+
+```bash
+kubectl -n lightdash get ingress lightdash \
+  -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+```
+
+Open that address and register the first user. If you passed `hostname`, point a DNS record
+at the load balancer and use your own address instead.
+
+## 5. Check on it
+
+```bash
+kubectl -n lightdash get pods
+kubectl -n lightdash logs deploy/lightdash
+```
+
+The database password and `LIGHTDASH_SECRET` live in Secrets Manager and are copied into the
+cluster by the External Secrets Operator. If the Lightdash pod is stuck in
+`CreateContainerConfigError`, the copy has not completed yet:
+
+```bash
+kubectl -n lightdash get externalsecrets
+kubectl -n external-secrets logs deploy/external-secrets
+```
+
+To read the database password:
+
+```bash
+aws secretsmanager get-secret-value --secret-id SECRET_ARN \
+  --query SecretString --output text
+```
+
+The ARN is a stack output.
+
+## 6. Upgrade
+
+Change the chart version and redeploy:
+
+```bash
+npx cdk deploy -c chartVersion=2.10.242
+```
+
+## 7. Remove everything
+
+```bash
+npx cdk destroy
+```
+
+By default this deletes the database and the bucket contents along with the cluster. Pass
+`-c retainData=true` on the original deploy if you want the database snapshotted and the
+bucket kept instead.
+
+If destroy fails while deleting the VPC, the cause is usually a load balancer that outlived
+its Ingress. Delete the load balancer and its security group, then run destroy again.


### PR DESCRIPTION
Adds a self-contained CDK application under deploy/aws-cdk that provisions VPC, EKS, RDS PostgreSQL, S3, IAM and Secrets Manager resources, then installs the published lightdash chart against them.

The chart is consumed from https://lightdash.github.io/helm-charts by version and is not modified, vendored or patched. Nothing under charts/ changes, and helm install into an existing cluster is unaffected.

Credentials are generated into Secrets Manager and read from inside the cluster by the External Secrets Operator, so the only credential dynamic reference in the template is the RDS master password. S3 access uses IRSA rather than access keys.

Deployed and destroyed end to end in us-west-2 before submission, which caught five things that synth, helm template and a kind install all passed over:

- postgresVersion is the major family rather than a pinned minor, because RDS had already retired the minor the default named.
- The helm release waits 13 minutes rather than 15. Fifteen is exactly the timeout of the Lambda CDK runs kubectl in, so the Lambda was killed mid-wait and the retry found the release pending-install, which no redeploy clears.
- The cluster runs in API_AND_CONFIG_MAP and adminRoleArn produces an access entry. Under CONFIG_MAP alone kubectl refuses the credentials that created the cluster and there is no way to add them.
- The release depends on the load balancer controller and the namespace on the node group. Without that the controller can be torn down before the Ingress whose finalizer only it removes, leaving the namespace Terminating, the load balancer running and the VPC undeletable.
- PGSSLMODE is no-verify rather than require. The value reaches node-postgres rather than libpq, so require left Node verifying the RDS chain against a trust store with no Amazon root and every start failed before migrating.

Closes #143