### PR TITLE
feat: make backend readiness probe path configurable

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.10.263
+version: 2.11.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.10.263](https://img.shields.io/badge/Version-2.10.263-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.169.1](https://img.shields.io/badge/AppVersion-1.169.1-informational?style=flat-square)
+![Version: 2.11.0](https://img.shields.io/badge/Version-2.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.169.1](https://img.shields.io/badge/AppVersion-1.169.1-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -104,6 +104,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | appBuildWorker.port | int | `8080` |  |
 | appBuildWorker.readinessProbe.failureThreshold | int | `2` |  |
 | appBuildWorker.readinessProbe.initialDelaySeconds | int | `5` |  |
+| appBuildWorker.readinessProbe.path | string | `"/api/v1/health"` |  |
 | appBuildWorker.readinessProbe.periodSeconds | int | `5` |  |
 | appBuildWorker.readinessProbe.timeoutSeconds | int | `5` |  |
 | appBuildWorker.replicas | int | `1` |  |
@@ -172,6 +173,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.livenessProbe.timeoutSeconds | int | `15` |  |
 | lightdashBackend.readinessProbe.failureThreshold | int | `2` |  |
 | lightdashBackend.readinessProbe.initialDelaySeconds | int | `5` |  |
+| lightdashBackend.readinessProbe.path | string | `"/api/v1/health"` |  |
 | lightdashBackend.readinessProbe.periodSeconds | int | `5` |  |
 | lightdashBackend.readinessProbe.timeoutSeconds | int | `5` |  |
 | lightdashBackend.startupProbe.failureThreshold | int | `18` |  |
@@ -257,6 +259,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | preAggregateNatsWorker.port | int | `8080` |  |
 | preAggregateNatsWorker.readinessProbe.failureThreshold | int | `2` |  |
 | preAggregateNatsWorker.readinessProbe.initialDelaySeconds | int | `5` |  |
+| preAggregateNatsWorker.readinessProbe.path | string | `"/api/v1/health"` |  |
 | preAggregateNatsWorker.readinessProbe.periodSeconds | int | `5` |  |
 | preAggregateNatsWorker.readinessProbe.timeoutSeconds | int | `5` |  |
 | preAggregateNatsWorker.replicas | int | `1` |  |
@@ -283,6 +286,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | scheduler.port | int | `8080` |  |
 | scheduler.readinessProbe.failureThreshold | int | `2` |  |
 | scheduler.readinessProbe.initialDelaySeconds | int | `5` |  |
+| scheduler.readinessProbe.path | string | `"/api/v1/health"` |  |
 | scheduler.readinessProbe.periodSeconds | int | `5` |  |
 | scheduler.readinessProbe.timeoutSeconds | int | `5` |  |
 | scheduler.replicas | int | `1` |  |
@@ -326,6 +330,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | warehouseNatsWorker.port | int | `8080` |  |
 | warehouseNatsWorker.readinessProbe.failureThreshold | int | `2` |  |
 | warehouseNatsWorker.readinessProbe.initialDelaySeconds | int | `5` |  |
+| warehouseNatsWorker.readinessProbe.path | string | `"/api/v1/health"` |  |
 | warehouseNatsWorker.readinessProbe.periodSeconds | int | `5` |  |
 | warehouseNatsWorker.readinessProbe.timeoutSeconds | int | `5` |  |
 | warehouseNatsWorker.replicas | int | `1` |  |

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -122,7 +122,7 @@ spec:
             successThreshold: {{ .Values.lightdashBackend.readinessProbe.successThreshold }}
             {{- end }}
             httpGet:
-              path: /api/v1/health
+              path: {{ .Values.lightdashBackend.readinessProbe.path | default "/api/v1/health" }}
               port: {{ .Values.service.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -414,6 +414,9 @@ lightdashBackend:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
+    ## Probe endpoint path. /api/v1/health checks the database on every request.
+    ## /api/v1/readyz (backend only) is TTL-cached and gates on schema migration state.
+    path: /api/v1/health
   extraVolumeMounts: []
   extraVolumes: []
 
@@ -453,6 +456,10 @@ scheduler:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
+    ## Probe endpoint path. Worker processes serve their own health handler at
+    ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
+    ## they do not serve /api/v1/readyz.
+    path: /api/v1/health
   tasks:
     exclude:
     include:
@@ -494,6 +501,10 @@ appBuildWorker:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
+    ## Probe endpoint path. Worker processes serve their own health handler at
+    ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
+    ## they do not serve /api/v1/readyz.
+    path: /api/v1/health
   tasks:
     exclude:
     include: appGeneratePipeline
@@ -531,6 +542,10 @@ warehouseNatsWorker:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
+    ## Probe endpoint path. Worker processes serve their own health handler at
+    ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
+    ## they do not serve /api/v1/readyz.
+    path: /api/v1/health
   extraVolumeMounts: []
   extraVolumes: []
 
@@ -565,5 +580,9 @@ preAggregateNatsWorker:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
+    ## Probe endpoint path. Worker processes serve their own health handler at
+    ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
+    ## they do not serve /api/v1/readyz.
+    path: /api/v1/health
   extraVolumeMounts: []
   extraVolumes: []


### PR DESCRIPTION
Linear: SPK-1065

## What breaks today
When the database has a brief problem, Kubernetes stops sending traffic to every backend pod at once, and the whole instance goes down. That happens because the readiness check (the check that decides whether a pod should receive traffic) points at `/api/v1/health`, an endpoint that queries the database on every call. The path is hardcoded in the chart, so operators cannot change it.

## What this PR changes
The readiness path becomes a value: `lightdashBackend.readinessProbe.path`. The default stays `/api/v1/health`, so nothing changes for existing installs. Operators can now point readiness at `/api/v1/readyz`, which caches its answer and does not hit the database on every call. The worker template already supports `readinessProbe.path`; this PR documents those keys in values.yaml with an explicit default.

Switching the default to `/readyz` stays out of this PR. That is a behaviour change and belongs to the chart major (SPK-931).

## Justification
The readiness check tells Kubernetes if a pod can receive traffic. Our check uses `/api/v1/health`. That endpoint queries the database on each call. When the database is slow, all pods fail the check at the same time. The load balancer then removes all pods. The full instance goes down.

A better endpoint exists. It is `/api/v1/readyz`. It keeps its answer for 10 seconds. It does not query the database on each call. The chart has the old path as fixed text. No operator can select the new endpoint.

This PR makes the path a setting. The default value is the old path. A default install does not change. We proved this. The rendered output is equal to main, byte for byte. Each operator can now select the new endpoint. Each operator can also go back with one change.

## Verification
- `helm lint` passes.
- The default render is byte-identical to the render from main (a77211d), proven with the chart version normalised and all random inputs pinned.
- A render with `lightdashBackend.readinessProbe.path=/api/v1/readyz` changes the backend readiness path only; worker readiness is unchanged.

## Merge checklist
- [ ] Rebase on current main and re-bump `version` in Chart.yaml above the new main version. The release bot advances main several times a day. After every restack the three stacked PRs must stay strictly increasing against the new main, not only against each other. Verify at merge time.
