### PR TITLE
fix: default PodDisruptionBudget to maxUnavailable 1

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.11.0
+version: 2.12.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -74,15 +74,17 @@ podAntiAffinity:
 
 ### Pod Disruption Budget
 
-A Pod Disruption Budget is enabled by default to prevent all pods from being evicted simultaneously during voluntary disruptions:
+A Pod Disruption Budget is enabled by default. It permits one pod to be evicted during a voluntary disruption:
 
 ```yaml
 podDisruptionBudget:
   enabled: true
-  minAvailable: 1
+  maxUnavailable: 1
 ```
 
-**Important:** PDBs only work effectively when combined with multiple replicas. With `replicaCount: 1`, the PDB cannot prevent downtime.
+Set `minAvailable` to pin a minimum number of available pods instead. When both fields are set, `minAvailable` takes precedence and `maxUnavailable` is ignored. Both fields accept zero.
+
+**Important:** With `replicaCount: 1`, the default permits the only pod to be evicted, so it does not prevent downtime.
 
 ## Values
 

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -229,7 +229,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | podAntiAffinity.node | string | `"hard"` |  |
 | podAntiAffinity.zone | string | `"soft"` |  |
 | podDisruptionBudget.enabled | bool | `true` |  |
-| podDisruptionBudget.minAvailable | int | `1` |  |
+| podDisruptionBudget.maxUnavailable | int | `1` |  |
 | podLabels | object | `{}` |  |
 | podSecurityContext | object | `{}` |  |
 | postgresql.auth.database | string | `"lightdash"` |  |

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.11.0](https://img.shields.io/badge/Version-2.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.169.1](https://img.shields.io/badge/AppVersion-1.169.1-informational?style=flat-square)
+![Version: 2.12.0](https://img.shields.io/badge/Version-2.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.169.1](https://img.shields.io/badge/AppVersion-1.169.1-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -68,15 +68,17 @@ podAntiAffinity:
 
 ### Pod Disruption Budget
 
-A Pod Disruption Budget is enabled by default to prevent all pods from being evicted simultaneously during voluntary disruptions:
+A Pod Disruption Budget is enabled by default. It permits one pod to be evicted during a voluntary disruption:
 
 ```yaml
 podDisruptionBudget:
   enabled: true
-  minAvailable: 1
+  maxUnavailable: 1
 ```
 
-**Important:** PDBs only work effectively when combined with multiple replicas. With `replicaCount: 1`, the PDB cannot prevent downtime.
+Set `minAvailable` to pin a minimum number of available pods instead. When both fields are set, `minAvailable` takes precedence and `maxUnavailable` is ignored. Both fields accept zero.
+
+**Important:** With `replicaCount: 1`, the default permits the only pod to be evicted, so it does not prevent downtime.
 
 ## Values
 

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -322,9 +322,9 @@ metadata:
     {{- include "lightdash.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $component }}
 spec:
-  {{- if and (hasKey $pdbConfig "minAvailable") (ne $pdbConfig.minAvailable nil) }}
+  {{- if and (hasKey $pdbConfig "minAvailable") (not (kindIs "invalid" $pdbConfig.minAvailable)) }}
   minAvailable: {{ $pdbConfig.minAvailable }}
-  {{- else if and (hasKey $pdbConfig "maxUnavailable") (ne $pdbConfig.maxUnavailable nil) }}
+  {{- else if and (hasKey $pdbConfig "maxUnavailable") (not (kindIs "invalid" $pdbConfig.maxUnavailable)) }}
   maxUnavailable: {{ $pdbConfig.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -322,9 +322,9 @@ metadata:
     {{- include "lightdash.labels" $root | nindent 4 }}
     app.kubernetes.io/component: {{ $component }}
 spec:
-  {{- if $pdbConfig.minAvailable }}
+  {{- if and (hasKey $pdbConfig "minAvailable") (ne $pdbConfig.minAvailable nil) }}
   minAvailable: {{ $pdbConfig.minAvailable }}
-  {{- else if $pdbConfig.maxUnavailable }}
+  {{- else if and (hasKey $pdbConfig "maxUnavailable") (ne $pdbConfig.maxUnavailable nil) }}
   maxUnavailable: {{ $pdbConfig.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -324,8 +324,7 @@ metadata:
 spec:
   {{- if $pdbConfig.minAvailable }}
   minAvailable: {{ $pdbConfig.minAvailable }}
-  {{- end }}
-  {{- if $pdbConfig.maxUnavailable }}
+  {{- else if $pdbConfig.maxUnavailable }}
   maxUnavailable: {{ $pdbConfig.maxUnavailable }}
   {{- end }}
   selector:

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -108,10 +108,17 @@ autoscaling:
   targetCPUUtilizationPercentage: 80
   # targetMemoryUtilizationPercentage: 80
 
+## Pod disruption budget for the backend and worker deployments.
+## maxUnavailable 1 permits one voluntary eviction at any replica count, so node
+## drains and cluster upgrades complete on a single-replica install.
+## With replicaCount above 1 the budget keeps all but one pod serving.
+## To pin a floor instead, set minAvailable. When minAvailable is set it takes
+## precedence and maxUnavailable is ignored, so an existing minAvailable override
+## keeps working across an upgrade to this chart version.
 podDisruptionBudget:
   enabled: true
-  minAvailable: 1
-  # maxUnavailable: 50%
+  maxUnavailable: 1
+  # minAvailable: 1
 
 nodeSelector: {}
 


### PR DESCRIPTION
Linear: SPK-1066

## What breaks today
On a default install, cluster maintenance hangs. `kubectl drain` never finishes, and node upgrades and autoscaler scale-downs get stuck on the Lightdash namespace. The cause: the chart ships a PodDisruptionBudget (a Kubernetes rule for how many pods may be deliberately shut down at once) that requires one pod to stay up, while the default install runs exactly one pod. One required minus one existing leaves zero pods that may ever be shut down on purpose.

## What this PR changes
The default budget becomes `maxUnavailable: 1`: at most one pod may be deliberately shut down at a time. A single-pod install can now be drained. A multi-pod install still keeps all but one pod serving. This is a deliberate default change: the old default is the bug.

Operators who set `minAvailable` themselves keep their setting. The template now treats the two fields as mutually exclusive, and `minAvailable` wins when both are present after the values merge. Without that rule, an existing `minAvailable` override plus the new default would render both fields in one budget, which Kubernetes rejects, and `helm upgrade` would fail.

## Justification
A disruption budget is a Kubernetes rule. The rule sets how many pods Kubernetes can stop on purpose during maintenance. Our rule says "keep 1 pod at all times". The default install has exactly 1 pod. Thus Kubernetes can never stop that pod. A node drain waits forever. Node upgrades and scale-downs stop on the Lightdash namespace.

This PR changes the rule to "stop at most 1 pod at a time". The single pod install can now be drained. An install with 2 pods keeps 1 pod in service, the same as before. An install with 3 or more pods becomes more safe, not less.

Some operators set the old rule in their own values. Their rule stays in effect. The template gives their value priority. Their upgrade cannot fail. We proved all three cases with rendered output.

The old default is the defect. That is why this PR changes behaviour now and does not wait for the chart major.

## Verification
- `helm lint` passes.
- Three renders each produce exactly one of the two fields: stock defaults give `maxUnavailable: 1`; an operator `minAvailable=1` override gives `minAvailable` only (the upgrade-migration case); a `maxUnavailable=2` override gives `maxUnavailable: 2` only.
- Rendered budgets for 1 and 3 replicas were parsed and asserted: at least one eviction is always allowed, and at least one pod keeps serving in the multi-replica case.

## Merge checklist
- [ ] Rebase on current main and re-bump `version` in Chart.yaml above the new main version. The release bot advances main several times a day. After every restack the three stacked PRs must stay strictly increasing against the new main, not only against each other. Verify at merge time.
