### PR TITLE
feat: add preStop hook and configurable update strategy

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.12.1
+version: 2.13.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.12.1](https://img.shields.io/badge/Version-2.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.170.0](https://img.shields.io/badge/AppVersion-1.170.0-informational?style=flat-square)
+![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.170.0](https://img.shields.io/badge/AppVersion-1.170.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -99,6 +99,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | appBuildWorker.enabled | bool | `false` |  |
 | appBuildWorker.extraVolumeMounts | list | `[]` |  |
 | appBuildWorker.extraVolumes | list | `[]` |  |
+| appBuildWorker.lifecycle | object | `{}` |  |
 | appBuildWorker.livenessProbe.failureThreshold | int | `20` |  |
 | appBuildWorker.livenessProbe.initialDelaySeconds | int | `5` |  |
 | appBuildWorker.livenessProbe.periodSeconds | int | `15` |  |
@@ -117,6 +118,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | appBuildWorker.startupProbe.initialDelaySeconds | int | `5` |  |
 | appBuildWorker.startupProbe.periodSeconds | int | `10` |  |
 | appBuildWorker.startupProbe.timeoutSeconds | int | `10` |  |
+| appBuildWorker.strategy | object | `{}` |  |
 | appBuildWorker.tasks.exclude | string | `nil` |  |
 | appBuildWorker.tasks.include | string | `"appGeneratePipeline"` |  |
 | appBuildWorker.terminationGracePeriodSeconds | int | `90` |  |
@@ -169,6 +171,9 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | initContainers | list | `[]` |  |
 | lightdashBackend.extraVolumeMounts | list | `[]` |  |
 | lightdashBackend.extraVolumes | list | `[]` |  |
+| lightdashBackend.lifecycle.preStop.exec.command[0] | string | `"sh"` |  |
+| lightdashBackend.lifecycle.preStop.exec.command[1] | string | `"-c"` |  |
+| lightdashBackend.lifecycle.preStop.exec.command[2] | string | `"sleep 10"` |  |
 | lightdashBackend.livenessProbe.failureThreshold | int | `6` |  |
 | lightdashBackend.livenessProbe.initialDelaySeconds | int | `5` |  |
 | lightdashBackend.livenessProbe.periodSeconds | int | `15` |  |
@@ -182,6 +187,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.startupProbe.initialDelaySeconds | int | `5` |  |
 | lightdashBackend.startupProbe.periodSeconds | int | `10` |  |
 | lightdashBackend.startupProbe.timeoutSeconds | int | `10` |  |
+| lightdashBackend.strategy | object | `{}` |  |
 | lightdashBackend.terminationGracePeriodSeconds | int | `90` |  |
 | migrationJob.affinity | object | `{}` |  |
 | migrationJob.backoffLimit | int | `10` |  |
@@ -254,6 +260,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | preAggregateNatsWorker.enabled | bool | `false` |  |
 | preAggregateNatsWorker.extraVolumeMounts | list | `[]` |  |
 | preAggregateNatsWorker.extraVolumes | list | `[]` |  |
+| preAggregateNatsWorker.lifecycle | object | `{}` |  |
 | preAggregateNatsWorker.livenessProbe.failureThreshold | int | `20` |  |
 | preAggregateNatsWorker.livenessProbe.initialDelaySeconds | int | `5` |  |
 | preAggregateNatsWorker.livenessProbe.periodSeconds | int | `15` |  |
@@ -272,6 +279,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | preAggregateNatsWorker.startupProbe.initialDelaySeconds | int | `5` |  |
 | preAggregateNatsWorker.startupProbe.periodSeconds | int | `10` |  |
 | preAggregateNatsWorker.startupProbe.timeoutSeconds | int | `10` |  |
+| preAggregateNatsWorker.strategy | object | `{}` |  |
 | preAggregateNatsWorker.terminationGracePeriodSeconds | int | `90` |  |
 | preAggregateNatsWorker.type | string | `"nats"` |  |
 | replicaCount | int | `1` | Specify the number of lightdash instances. |
@@ -281,6 +289,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | scheduler.enabled | bool | `false` |  |
 | scheduler.extraVolumeMounts | list | `[]` |  |
 | scheduler.extraVolumes | list | `[]` |  |
+| scheduler.lifecycle | object | `{}` |  |
 | scheduler.livenessProbe.failureThreshold | int | `20` |  |
 | scheduler.livenessProbe.initialDelaySeconds | int | `5` |  |
 | scheduler.livenessProbe.periodSeconds | int | `15` |  |
@@ -299,6 +308,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | scheduler.startupProbe.initialDelaySeconds | int | `5` |  |
 | scheduler.startupProbe.periodSeconds | int | `10` |  |
 | scheduler.startupProbe.timeoutSeconds | int | `10` |  |
+| scheduler.strategy | object | `{}` |  |
 | scheduler.tasks.exclude | string | `nil` |  |
 | scheduler.tasks.include | string | `nil` |  |
 | scheduler.terminationGracePeriodSeconds | int | `90` |  |
@@ -325,6 +335,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | warehouseNatsWorker.enabled | bool | `false` |  |
 | warehouseNatsWorker.extraVolumeMounts | list | `[]` |  |
 | warehouseNatsWorker.extraVolumes | list | `[]` |  |
+| warehouseNatsWorker.lifecycle | object | `{}` |  |
 | warehouseNatsWorker.livenessProbe.failureThreshold | int | `20` |  |
 | warehouseNatsWorker.livenessProbe.initialDelaySeconds | int | `5` |  |
 | warehouseNatsWorker.livenessProbe.periodSeconds | int | `15` |  |
@@ -343,6 +354,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | warehouseNatsWorker.startupProbe.initialDelaySeconds | int | `5` |  |
 | warehouseNatsWorker.startupProbe.periodSeconds | int | `10` |  |
 | warehouseNatsWorker.startupProbe.timeoutSeconds | int | `10` |  |
+| warehouseNatsWorker.strategy | object | `{}` |  |
 | warehouseNatsWorker.terminationGracePeriodSeconds | int | `90` |  |
 | warehouseNatsWorker.type | string | `"nats"` |  |
 

--- a/charts/lightdash/templates/_worker-deployment.tpl
+++ b/charts/lightdash/templates/_worker-deployment.tpl
@@ -18,6 +18,10 @@ metadata:
     app.kubernetes.io/component: {{ $component }}
 spec:
   replicas: {{ $workerConfig.replicas }}
+  {{- with $workerConfig.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "lightdash.selectorLabels" $root | nindent 6 }}
@@ -163,6 +167,10 @@ spec:
               port: {{ $workerConfig.port }}
           resources:
             {{- toYaml $workerConfig.resources | nindent 12 }}
+          {{- with $workerConfig.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or $volumeMounts $root.Values.ssl.enabled }}
           volumeMounts:
             {{- if $volumeMounts }}

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -11,6 +11,10 @@ spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
+  {{- with .Values.lightdashBackend.strategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "lightdash.selectorLabels" . | nindent 6 }}
@@ -126,6 +130,10 @@ spec:
               port: {{ .Values.service.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.lightdashBackend.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or $volumeMounts .Values.ssl.enabled }}
           volumeMounts:
             {{- if $volumeMounts }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -424,6 +424,20 @@ lightdashBackend:
     ## Probe endpoint path. /api/v1/health checks the database on every request.
     ## /api/v1/readyz (backend only) is TTL-cached and gates on schema migration state.
     path: /api/v1/health
+  ## Container lifecycle hooks. The default preStop sleep keeps the pod serving
+  ## while the Service endpoint removal propagates, so a rollout does not send
+  ## requests to a pod that has begun shutting down. 10s is a conventional value
+  ## that exceeds typical endpoint propagation; it is not derived from a
+  ## measurement. Raise it if your load balancer detaches slowly, and keep it
+  ## well below terminationGracePeriodSeconds (default 90), which covers the
+  ## sleep plus graceful shutdown of in-flight work.
+  lifecycle:
+    preStop:
+      exec:
+        command: ["sh", "-c", "sleep 10"]
+  ## Deployment update strategy. Empty uses the Kubernetes default RollingUpdate.
+  ## Set type: Recreate for an upgrade declared breaking.
+  strategy: {}
   extraVolumeMounts: []
   extraVolumes: []
 
@@ -467,6 +481,14 @@ scheduler:
     ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
     ## they do not serve /api/v1/readyz.
     path: /api/v1/health
+  ## Container lifecycle hooks. Empty by default: worker pods take no Service
+  ## traffic, so there is no endpoint-removal race to cover, and a preStop delay
+  ## postpones SIGTERM and with it the release of in-flight jobs for retry.
+  ## Set a hook only if your topology needs one.
+  lifecycle: {}
+  ## Deployment update strategy. Empty uses the Kubernetes default RollingUpdate.
+  ## Set type: Recreate for an upgrade declared breaking.
+  strategy: {}
   tasks:
     exclude:
     include:
@@ -512,6 +534,14 @@ appBuildWorker:
     ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
     ## they do not serve /api/v1/readyz.
     path: /api/v1/health
+  ## Container lifecycle hooks. Empty by default: worker pods take no Service
+  ## traffic, so there is no endpoint-removal race to cover, and a preStop delay
+  ## postpones SIGTERM and with it the release of in-flight jobs for retry.
+  ## Set a hook only if your topology needs one.
+  lifecycle: {}
+  ## Deployment update strategy. Empty uses the Kubernetes default RollingUpdate.
+  ## Set type: Recreate for an upgrade declared breaking.
+  strategy: {}
   tasks:
     exclude:
     include: appGeneratePipeline
@@ -553,6 +583,14 @@ warehouseNatsWorker:
     ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
     ## they do not serve /api/v1/readyz.
     path: /api/v1/health
+  ## Container lifecycle hooks. Empty by default: worker pods take no Service
+  ## traffic, so there is no endpoint-removal race to cover, and a preStop delay
+  ## postpones SIGTERM and with it the release of in-flight jobs for retry.
+  ## Set a hook only if your topology needs one.
+  lifecycle: {}
+  ## Deployment update strategy. Empty uses the Kubernetes default RollingUpdate.
+  ## Set type: Recreate for an upgrade declared breaking.
+  strategy: {}
   extraVolumeMounts: []
   extraVolumes: []
 
@@ -591,5 +629,13 @@ preAggregateNatsWorker:
     ## /api/v1/health (in-memory worker state, no database query) and /api/v1/livez;
     ## they do not serve /api/v1/readyz.
     path: /api/v1/health
+  ## Container lifecycle hooks. Empty by default: worker pods take no Service
+  ## traffic, so there is no endpoint-removal race to cover, and a preStop delay
+  ## postpones SIGTERM and with it the release of in-flight jobs for retry.
+  ## Set a hook only if your topology needs one.
+  lifecycle: {}
+  ## Deployment update strategy. Empty uses the Kubernetes default RollingUpdate.
+  ## Set type: Recreate for an upgrade declared breaking.
+  strategy: {}
   extraVolumeMounts: []
   extraVolumes: []


### PR DESCRIPTION
Linear: SPK-1067

## What breaks today
During every upgrade, some in-flight requests fail. Kubernetes removes a stopping pod from the load balancer at the same time as it tells the pod to shut down, so for a short window the load balancer still sends requests to a pod that has stopped accepting them. Users see dropped requests on every rollout.

## What this PR changes
The backend pod now waits 10 seconds before shutting down (a `preStop` hook: a pause before shutdown so the load balancer stops sending work first). The pause is configurable through a new `lifecycle` value. This is a deliberate default change: every backend rollout becomes about 10 seconds slower per pod. The backend already shuts down cleanly on SIGTERM; the pause only closes the removal race. The 90-second grace period covers the pause plus in-flight work.

The 10-second value is a convention, not a measurement. It must exceed the time the load balancer takes to stop routing to the pod, which is independent of the readiness probe period. With container-native load balancing (GCP NEGs), the governing window is NEG endpoint detach plus any connection-draining timeout, and it can exceed 10 seconds. Deployments in that topology should derive their own value and set it in values.

Worker pods get no default pause. They take no traffic from the Service, so there is no race to close, and a pause would only delay the release of their in-flight jobs for retry. Their `lifecycle` key defaults to empty and can be set from values.

The PR also exposes the Deployment update `strategy` in values for backend and workers. The default is unchanged (rolling update). This is the operator-facing half of the breaking-change declaration we publish in the upgrade artifact: a release declared breaking wants `type: Recreate` (stop everything, then start the new version), and until now an operator could not set that without forking the chart.

## Justification
During a deploy, Kubernetes does two things at the same moment. It tells the pod to stop. It tells the load balancer to stop sending work to the pod. The second message is slow. For a short time, the load balancer sends work to a pod that stops. Those requests fail. This occurs on every deploy.

This PR makes the backend pod wait 10 seconds before it stops. In that time, the load balancer removes the pod. Then the pod stops with no work in flight. Each deploy becomes about 10 seconds slower per pod. The shutdown allowance is 90 seconds. The pause is safe inside it.

The 10 second value is a convention. It is not a measurement. It must be more than the time the load balancer needs to remove the pod. Operators on Google container-native load balancing can need a larger value. They can set one.

Worker pods do not get the pause. Worker pods receive no traffic from the load balancer. A pause on a worker has no benefit. It only delays the release of unfinished jobs.

The PR also makes the deploy strategy a setting. The default does not change. An operator with a breaking release can now select "stop all, then start new" without a fork of the chart.

## Verification
- `helm lint` passes.
- The default render has the preStop pause on the backend container only; worker containers have none; no Deployment sets a strategy.
- A render with `lightdashBackend.strategy.type=Recreate` sets the strategy on the backend Deployment.
- A render with a worker lifecycle set from values renders the hook on that worker.

## Merge checklist
- [ ] Rebase on current main and re-bump `version` in Chart.yaml above the new main version. The release bot advances main several times a day. After every restack the three stacked PRs must stay strictly increasing against the new main, not only against each other. Verify at merge time.
