### PR TITLE
docs: explain the migration startup budget

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.0
+version: 2.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.13.0](https://img.shields.io/badge/Version-2.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.170.0](https://img.shields.io/badge/AppVersion-1.170.0-informational?style=flat-square)
+![Version: 2.13.1](https://img.shields.io/badge/Version-2.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.170.0](https://img.shields.io/badge/AppVersion-1.170.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -38,6 +38,32 @@ helm install lightdash lightdash/lightdash \
   --set secrets.PGPASSWORD=changeme \
 
 ```
+
+### Database migration startup budget
+
+The backend image runs database migrations before it starts the HTTP server when `migrationJob.enabled` is `false`. The backend startup probe covers this full startup path.
+
+The default startup probe budget is about 185 seconds:
+
+```text
+initialDelaySeconds + (periodSeconds * failureThreshold)
+5 + (10 * 18) = 185 seconds
+```
+
+The migration follower wait budget defaults to 30 minutes through `MIGRATION_WAIT_TIMEOUT_MS`. This wait budget does not limit the time that the lease holder spends running a migration. Size the startup probe for the follower wait budget plus the longest expected migration.
+
+For example, a 30-minute follower wait and a 20-minute migration need about 50 minutes. The following values provide about 50 minutes and 5 seconds:
+
+```yaml
+lightdashBackend:
+  startupProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 10
+    periodSeconds: 10
+    failureThreshold: 300
+```
+
+For long migrations, set `migrationJob.enabled=true`. The migration hook Job has no startup probe, and the backend pods start after the Job completes.
 
 ## Requirements
 
@@ -183,10 +209,11 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.readinessProbe.path | string | `"/api/v1/health"` |  |
 | lightdashBackend.readinessProbe.periodSeconds | int | `5` |  |
 | lightdashBackend.readinessProbe.timeoutSeconds | int | `5` |  |
-| lightdashBackend.startupProbe.failureThreshold | int | `18` |  |
-| lightdashBackend.startupProbe.initialDelaySeconds | int | `5` |  |
-| lightdashBackend.startupProbe.periodSeconds | int | `10` |  |
-| lightdashBackend.startupProbe.timeoutSeconds | int | `10` |  |
+| lightdashBackend.startupProbe | object | `{"failureThreshold":18,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":10}` | Backend startup probe. When migrationJob.enabled is false, size its approximate initialDelaySeconds + (periodSeconds * failureThreshold) budget to cover the 30-minute MIGRATION_WAIT_TIMEOUT_MS default plus the longest expected migration. Enable migrationJob.enabled to run migrations in a hook Job without a startup probe. |
+| lightdashBackend.startupProbe.failureThreshold | int | `18` | Failed backend startup probes before Kubernetes restarts the container |
+| lightdashBackend.startupProbe.initialDelaySeconds | int | `5` | Delay before the first backend startup probe |
+| lightdashBackend.startupProbe.periodSeconds | int | `10` | Interval between backend startup probes |
+| lightdashBackend.startupProbe.timeoutSeconds | int | `10` | Timeout for each backend startup probe |
 | lightdashBackend.strategy | object | `{}` |  |
 | lightdashBackend.terminationGracePeriodSeconds | int | `90` |  |
 | migrationJob.affinity | object | `{}` |  |

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -40,6 +40,32 @@ helm install lightdash lightdash/lightdash \
 
 ```
 
+### Database migration startup budget
+
+The backend image runs database migrations before it starts the HTTP server when `migrationJob.enabled` is `false`. The backend startup probe covers this full startup path.
+
+The default startup probe budget is about 185 seconds:
+
+```text
+initialDelaySeconds + (periodSeconds * failureThreshold)
+5 + (10 * 18) = 185 seconds
+```
+
+The migration follower wait budget defaults to 30 minutes through `MIGRATION_WAIT_TIMEOUT_MS`. This wait budget does not limit the time that the lease holder spends running a migration. Size the startup probe for the follower wait budget plus the longest expected migration.
+
+For example, a 30-minute follower wait and a 20-minute migration need about 50 minutes. The following values provide about 50 minutes and 5 seconds:
+
+```yaml
+lightdashBackend:
+  startupProbe:
+    initialDelaySeconds: 5
+    timeoutSeconds: 10
+    periodSeconds: 10
+    failureThreshold: 300
+```
+
+For long migrations, set `migrationJob.enabled=true`. The migration hook Job has no startup probe, and the backend pods start after the Job completes.
+
 {{ template "chart.requirementsSection" . }}
 
 ## High Availability

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -403,11 +403,16 @@ lightdashBackend:
   ## In some older Kubernetes versions, the initialDelaySeconds might be ignored if periodSeconds was set to a value higher than initialDelaySeconds.
   ## However, in current versions, initialDelaySeconds is always honored and the probe will not start until after this initial delay.
   ## https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes
+  # -- Backend startup probe. When migrationJob.enabled is false, size its approximate initialDelaySeconds + (periodSeconds * failureThreshold) budget to cover the 30-minute MIGRATION_WAIT_TIMEOUT_MS default plus the longest expected migration. Enable migrationJob.enabled to run migrations in a hook Job without a startup probe.
   startupProbe:
     ## 5 + (10 * 18) = ~185s max startup
+    # -- Delay before the first backend startup probe
     initialDelaySeconds: 5
+    # -- Timeout for each backend startup probe
     timeoutSeconds: 10
+    # -- Interval between backend startup probes
     periodSeconds: 10
+    # -- Failed backend startup probes before Kubernetes restarts the container
     failureThreshold: 18
   livenessProbe:
     ## 5 + (15 * 6) = ~95s to restart


### PR DESCRIPTION
## Summary

- Explain the backend startup probe and migration wait budgets.
- Add a worked startup probe sizing example.
- Recommend the migration hook Job for long migrations.
- Bump the chart patch version to 2.10.252.

The defaults do not change.

## Why

The backend image runs migrations before it starts the HTTP server. The default startup probe restarts the container after about 185 seconds. A follower can wait for a migration lease for 30 minutes. The startup budget must cover that wait and the migration runtime.

## Recommendation

Keep option 1 for SPK-1086. It makes the current values safe to configure. It does not change a default.

Use `migrationJob.enabled=true` for long migrations. The hook Job has no startup probe. The backend pods start after the Job completes.

Option 2 is viable with an init container. `migrate wait` does not deadlock with the current CLI. It calls the follower loop with promotion enabled. One pod claims an absent or expired lease and runs the pending migrations. The other pods follow that lease holder.

The init container does not need `migrate up` to avoid a deadlock. However, `migrate up` is the safer command for this role. It runs the migration preflight gate before it enters the same holder and follower flow. `migrate wait` skips that preflight gate when it promotes itself.

The chart must also start the main container without the migration entrypoint. Otherwise, the main container runs `migrate up` again after the init container completes. The existing migration hook Job already handles this command change. An init-container option is viable, but it adds more chart logic than the existing Job.

## Checks

- `helm lint charts/lightdash`
- `helm template` with custom values for every backend startup probe field
- `helm-docs` generation and idempotence check

Linear: SPK-1086
