### PR TITLE
ci: test installs and upgrades, gate the auto-release, modernise the matrix

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/ci-release.yml:
+    ignore:
+      - 'unexpected key "queue" for "concurrency" section'

--- a/.github/ct-install.yaml
+++ b/.github/ct-install.yaml
@@ -1,1 +1,0 @@
-target-branch: main

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,7 +8,6 @@ on:
 concurrency:
   group: chart-release
   cancel-in-progress: false
-  queue: max
 
 jobs:
   test:
@@ -34,14 +33,9 @@ jobs:
       - name: Clean up fresh install
         run: |
           helm uninstall lightdash --wait || true
-          kubectl delete pvc --all --wait=false --request-timeout=10s
-          deadline=$((SECONDS + 120))
-          while true; do
-            pvc_names="$(kubectl get pvc -o name --request-timeout=10s)"
-            [[ -z "$pvc_names" ]] && break
-            ((SECONDS < deadline)) || exit 1
-            sleep 2
-          done
+          kubectl delete statefulset lightdash-postgresql --ignore-not-found --wait --timeout=120s --request-timeout=10s
+          kubectl delete pod lightdash-postgresql-0 --ignore-not-found --wait --timeout=120s --request-timeout=10s
+          kubectl delete pvc --all --wait --timeout=120s --request-timeout=10s
 
       - name: Run upgrade rehearsal
         run: scripts/rehearsal/rehearse.sh --to local --skip-cluster

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,6 +8,7 @@ on:
 concurrency:
   group: chart-release
   cancel-in-progress: false
+  queue: max
 
 jobs:
   test:
@@ -33,10 +34,17 @@ jobs:
       - name: Clean up fresh install
         run: |
           helm uninstall lightdash --wait || true
-          kubectl delete pvc --all --wait || true
+          kubectl delete pvc --all --wait=false --request-timeout=10s
+          deadline=$((SECONDS + 120))
+          while true; do
+            pvc_names="$(kubectl get pvc -o name --request-timeout=10s)"
+            [[ -z "$pvc_names" ]] && break
+            ((SECONDS < deadline)) || exit 1
+            sleep 2
+          done
 
       - name: Run upgrade rehearsal
-        run: scripts/rehearsal/rehearse.sh --from latest --to local --skip-cluster
+        run: scripts/rehearsal/rehearse.sh --to local --skip-cluster
 
   release:
     needs: test

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -5,12 +5,45 @@ on:
     branches:
       - main
 
+concurrency:
+  group: chart-release
+  cancel-in-progress: false
+
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.21.4
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.14.0
+        with:
+          node_image: kindest/node:v1.35.0
+
+      - name: Run fresh install rehearsal
+        run: scripts/rehearsal/rehearse.sh --install-only --to local --skip-cluster
+
+      - name: Clean up fresh install
+        run: |
+          helm uninstall lightdash --wait || true
+          kubectl delete pvc --all --wait || true
+
+      - name: Run upgrade rehearsal
+        run: scripts/rehearsal/rehearse.sh --from latest --to local --skip-cluster
+
   release:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -20,9 +53,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
-          version: v3.4.0
+          version: v3.21.4
 
       - name: Add Helm dependency repos
         run: |
@@ -32,7 +65,7 @@ jobs:
           helm repo update
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.1.0
+        uses: helm/chart-releaser-action@v1.7.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -8,6 +8,7 @@ on:
 concurrency:
   group: chart-release
   cancel-in-progress: false
+  queue: max
 
 jobs:
   test:

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -38,6 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 35
     strategy:
+      fail-fast: false
       matrix:
         # When changing versions here, check that the version exists at: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=last_updated
         k8s:

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -70,7 +70,7 @@ jobs:
           kubectl delete pvc --all --wait --timeout=120s --request-timeout=10s
 
       - name: Run upgrade rehearsal
-        run: scripts/rehearsal/rehearse.sh --from 2.13.1 --to local --skip-cluster
+        run: scripts/rehearsal/rehearse.sh --to local --skip-cluster
 
   automerge:
     needs: [lint, test]

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -70,7 +70,7 @@ jobs:
           kubectl delete pvc --all --wait --timeout=120s --request-timeout=10s
 
       - name: Run upgrade rehearsal
-        run: scripts/rehearsal/rehearse.sh --to local --skip-cluster
+        run: scripts/rehearsal/rehearse.sh --from 2.13.1 --to local --skip-cluster
 
   automerge:
     needs: [lint, test]

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -64,10 +64,17 @@ jobs:
       - name: Clean up fresh install
         run: |
           helm uninstall lightdash --wait || true
-          kubectl delete pvc --all --wait || true
+          kubectl delete pvc --all --wait=false --request-timeout=10s
+          deadline=$((SECONDS + 120))
+          while true; do
+            pvc_names="$(kubectl get pvc -o name --request-timeout=10s)"
+            [[ -z "$pvc_names" ]] && break
+            ((SECONDS < deadline)) || exit 1
+            sleep 2
+          done
 
       - name: Run upgrade rehearsal
-        run: scripts/rehearsal/rehearse.sh --from latest --to local --skip-cluster
+        run: scripts/rehearsal/rehearse.sh --to local --skip-cluster
 
   automerge:
     needs: [lint, test]

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -64,14 +64,9 @@ jobs:
       - name: Clean up fresh install
         run: |
           helm uninstall lightdash --wait || true
-          kubectl delete pvc --all --wait=false --request-timeout=10s
-          deadline=$((SECONDS + 120))
-          while true; do
-            pvc_names="$(kubectl get pvc -o name --request-timeout=10s)"
-            [[ -z "$pvc_names" ]] && break
-            ((SECONDS < deadline)) || exit 1
-            sleep 2
-          done
+          kubectl delete statefulset lightdash-postgresql --ignore-not-found --wait --timeout=120s --request-timeout=10s
+          kubectl delete pod lightdash-postgresql-0 --ignore-not-found --wait --timeout=120s --request-timeout=10s
+          kubectl delete pvc --all --wait --timeout=120s --request-timeout=10s
 
       - name: Run upgrade rehearsal
         run: scripts/rehearsal/rehearse.sh --to local --skip-cluster

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -5,22 +5,22 @@ on: pull_request
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.2.0
+        uses: actions/checkout@v7
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
-          version: v3.7.2
+          version: v3.21.4
 
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v7
         with:
-          python-version: 3.7
+          python-version: '3.13'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Add bitnami repo for dependencies
         run: helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -35,48 +35,39 @@ jobs:
         run: ct lint --all
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
     strategy:
       matrix:
         # When changing versions here, check that the version exists at: https://hub.docker.com/r/kindest/node/tags?page=1&ordering=last_updated
         k8s:
-          - v1.21.2
-          - v1.22.5
-          - v1.23.3
+          - kindest/node:v1.35.0
+          - kindest/node:v1.34.3
+          - kindest/node:v1.33.7
     steps:
       - name: Checkout
-        uses: actions/checkout@v2.2.0
+        uses: actions/checkout@v7
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v5
         with:
-          version: v3.7.2
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: 3.7
-
-      - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.2.0
+          version: v3.21.4
 
       - name: Create kind ${{ matrix.k8s }} cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.14.0
         with:
-          node_image: kindest/node:${{ matrix.k8s }}
+          node_image: ${{ matrix.k8s }}
 
-      - name: Add browserless-chrome repo for dependencies
-        run: helm repo add browserless-chrome https://charts.sagikazarmark.dev
+      - name: Run fresh install rehearsal
+        run: scripts/rehearsal/rehearse.sh --install-only --to local --skip-cluster
 
-      - name: Add nats repo for dependencies
-        run: helm repo add nats https://nats-io.github.io/k8s/helm/charts/
-
-      - name: Install PostgreSQL dependency
+      - name: Clean up fresh install
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm install lightdashdb bitnami/postgresql --set auth.username=lightdash,auth.password=changeme,auth.database=lightdash --set primary.persistence.enabled=false
+          helm uninstall lightdash --wait || true
+          kubectl delete pvc --all --wait || true
 
-      - name: Run chart-testing (install)
-        run: ct install --config .github/ct-install.yaml --all
+      - name: Run upgrade rehearsal
+        run: scripts/rehearsal/rehearse.sh --from latest --to local --skip-cluster
 
   automerge:
     needs: [lint, test]
@@ -92,4 +83,3 @@ jobs:
           MERGE_FORKS: false
           MERGE_DELETE_BRANCH: true
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-

--- a/scripts/rehearsal/README.md
+++ b/scripts/rehearsal/README.md
@@ -34,7 +34,7 @@ scripts/rehearsal/rehearse.sh
 
 The default command installs the newest released chart older than the target chart. It upgrades the release to `charts/lightdash`. It seeds the database and the product API. It monitors traffic during the upgrade. It then checks the release, migrations, migration ledger, backend rollout, readiness, traffic, marker row, and user login.
 
-The current main branch can fail the zero-drop traffic assertion. A single backend replica has no pre-stop drain. PR #147 contains the pending fix. Keep the default allowance at zero until that fix lands.
+The default rehearsal does not override the backend readiness path. It tests the chart defaults for both install and upgrade.
 
 Use an older released chart as the starting point:
 

--- a/scripts/rehearsal/rehearse.sh
+++ b/scripts/rehearsal/rehearse.sh
@@ -49,6 +49,8 @@ ROLLOUT_OBSERVER_PID=""
 ROLLOUT_OBSERVER_FILE=""
 ROLLOUT_DEPLOYMENT_BEFORE=""
 ROLLOUT_DEPLOYMENT_AFTER=""
+POSTGRES_POD_UID_BEFORE=""
+POSTGRES_POD_UID_AFTER=""
 DRAIN_APP_NODE=""
 DRAIN_DB_NODE=""
 
@@ -815,15 +817,22 @@ backend_deployment_rollout_config() {
         jq -c '{replicas: .spec.replicas, strategy: .spec.strategy, availableReplicas: (.status.availableReplicas // 0), readyReplicas: (.status.readyReplicas // 0), updatedReplicas: (.status.updatedReplicas // 0)}'
 }
 
+postgres_pod_uid() {
+    kubectl get pod -n "$NAMESPACE" "$RELEASE_NAME-postgresql-0" -o jsonpath='{.metadata.uid}' 2>/dev/null || true
+}
+
 start_rollout_observer() {
     ROLLOUT_OBSERVER_FILE="$TEMP_DIR/backend-rollout.tsv"
     ROLLOUT_DEPLOYMENT_BEFORE="$(backend_deployment_rollout_config)"
+    POSTGRES_POD_UID_BEFORE="$(postgres_pod_uid)"
     (
         local sample_index=0
         while true; do
             local epoch
             local endpoint_state
             local pod_state
+            local postgres_endpoint_state
+            local postgres_pod_state
             epoch="$(date +%s)"
             endpoint_state="$(
                 kubectl get endpointslices.discovery.k8s.io -n "$NAMESPACE" -l "kubernetes.io/service-name=$RELEASE_NAME" -o json 2>/dev/null |
@@ -848,7 +857,31 @@ start_rollout_observer() {
                         deleting: (.metadata.deletionTimestamp // null)
                     }] | sort_by(.name)' 2>/dev/null || printf '[{"error":"pod-query-failed"}]'
             )"
-            printf '%s\t%s\t%s\t%s\n' "$epoch" "$sample_index" "$endpoint_state" "$pod_state"
+            postgres_endpoint_state="$(
+                kubectl get endpointslices.discovery.k8s.io -n "$NAMESPACE" -l "kubernetes.io/service-name=$RELEASE_NAME-postgresql" -o json 2>/dev/null |
+                    jq -c '{
+                        readyAddresses: ([.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | length),
+                        endpoints: ([.items[].endpoints[]? | {
+                            addresses: .addresses,
+                            ready: (if ((.conditions // {}) | has("ready")) then .conditions.ready else null end),
+                            serving: (if ((.conditions // {}) | has("serving")) then .conditions.serving else null end),
+                            terminating: (if ((.conditions // {}) | has("terminating")) then .conditions.terminating else null end),
+                            pod: (.targetRef.name // null)
+                        }] | sort_by(.pod))
+                    }' 2>/dev/null || printf '{"error":"postgres-endpoint-query-failed"}'
+            )"
+            postgres_pod_state="$(
+                kubectl get pod -n "$NAMESPACE" "$RELEASE_NAME-postgresql-0" -o json 2>/dev/null |
+                    jq -c '{
+                        name: .metadata.name,
+                        uid: .metadata.uid,
+                        ownerUid: (([.metadata.ownerReferences[]? | select(.kind == "StatefulSet")][0].uid) // null),
+                        phase: (.status.phase // null),
+                        ready: (([.status.conditions[]? | select(.type == "Ready")][0].status) // "Unknown"),
+                        deleting: (.metadata.deletionTimestamp // null)
+                    }' 2>/dev/null || printf '{"error":"postgres-pod-query-failed"}'
+            )"
+            printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$epoch" "$sample_index" "$endpoint_state" "$pod_state" "$postgres_endpoint_state" "$postgres_pod_state"
             sample_index=$((sample_index + 1))
             sleep 0.5
         done
@@ -875,14 +908,27 @@ print_rollout_timeline() {
     printf 'Backend rollout timeline (state changes from 0.5s samples):\n'
     awk -F '\t' -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" -v assertion="$TRAFFIC_ASSERT_EPOCH" '
         $1 ~ /^[0-9]+$/ && $1 >= start && $1 <= assertion {
-            state = $3 FS $4
+            state = $3 FS $4 FS $5 FS $6
             if (state != previous) {
                 phase = $1 <= end ? "helm-upgrade" : "post-upgrade"
-                printf "%s sample=%s phase=%s endpoints=%s pods=%s\n", $1, $2, phase, $3, $4
+                printf "%s sample=%s phase=%s backendEndpoints=%s backendPods=%s postgresEndpoints=%s postgresPod=%s\n", $1, $2, phase, $3, $4, $5, $6
                 previous = state
             }
         }
     ' "$ROLLOUT_OBSERVER_FILE"
+}
+
+assert_postgres_pod_uid_stable() {
+    POSTGRES_POD_UID_AFTER="$(postgres_pod_uid)"
+    if [[ -z "$POSTGRES_POD_UID_BEFORE" ]]; then
+        record_result "FAIL" "PostgreSQL pod UID" "the pod UID was unavailable before the upgrade"
+    elif [[ -z "$POSTGRES_POD_UID_AFTER" ]]; then
+        record_result "FAIL" "PostgreSQL pod UID" "the pod UID was unavailable after the upgrade"
+    elif [[ "$POSTGRES_POD_UID_BEFORE" == "$POSTGRES_POD_UID_AFTER" ]]; then
+        record_result "PASS" "PostgreSQL pod UID" "the pod UID remained $POSTGRES_POD_UID_AFTER"
+    else
+        record_result "FAIL" "PostgreSQL pod UID" "the pod UID changed from $POSTGRES_POD_UID_BEFORE to $POSTGRES_POD_UID_AFTER"
+    fi
 }
 
 start_traffic_monitor() {
@@ -1045,6 +1091,7 @@ assert_traffic() {
         printf 'Traffic anomaly timeline: none\n'
     fi
     print_rollout_timeline
+    assert_postgres_pod_uid_stable
     if [[ "$monitor_phase" != "Running" ]]; then
         record_result "FAIL" "Traffic monitor coverage" "the monitor phase is $monitor_phase after the ${window_seconds}s upgrade window"
     elif ((TRAFFIC_SAMPLE_COUNT == 0)); then

--- a/scripts/rehearsal/rehearse.sh
+++ b/scripts/rehearsal/rehearse.sh
@@ -808,7 +808,8 @@ capture_migration_baseline() {
 start_traffic_monitor() {
     local initial_samples
     local monitor_command
-    monitor_command="while true; do code=\$(curl -s -o /dev/null -w \"%{http_code}\" --max-time 2 http://lightdash:8080/api/v1/health || true); printf \"%s %s\\n\" \"\$(date +%s)\" \"\${code:-000}\"; sleep 0.5; done"
+    # The browser route represents user traffic through the Service without the database-backed diagnostics run by /api/v1/health.
+    monitor_command="while true; do epoch=\$(date +%s); output=\$(curl -sS -o /dev/null -w \"%{http_code} %{time_total}\" --max-time 10 http://lightdash:8080/ 2>/dev/null); curl_exit=\$?; set -- \$output; printf \"%s %s %s %s\\n\" \"\$epoch\" \"\${1:-000}\" \"\$curl_exit\" \"\${2:-0}\"; sleep 0.5; done"
     kubectl run -n "$NAMESPACE" "$TRAFFIC_POD" --image=curlimages/curl:8.12.1 --restart=Never --command -- sh -c "$monitor_command" >/dev/null
     TRAFFIC_CREATED=true
     kubectl wait -n "$NAMESPACE" --for=condition=Ready "pod/$TRAFFIC_POD" --timeout=5m >/dev/null
@@ -917,33 +918,53 @@ traffic_counts() {
     local logs
     logs="$(kubectl logs -n "$NAMESPACE" "$TRAFFIC_POD")"
     TRAFFIC_SAMPLE_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end {count += 1} END {print count + 0}')"
-    TRAFFIC_DROP_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $2 != "200" {count += 1} END {print count + 0}')"
-    TRAFFIC_DROP_DETAILS="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $2 != "200" {codes[$2] += 1} END {for (code in codes) printf "%s=%d ", code, codes[code]}' | sed 's/[[:space:]]*$//')"
+    TRAFFIC_REFUSED_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $3 == "7" {count += 1} END {print count + 0}')"
+    TRAFFIC_TIMEOUT_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $3 == "28" {count += 1} END {print count + 0}')"
+    TRAFFIC_5XX_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $3 == "0" && $2 ~ /^5[0-9][0-9]$/ {count += 1} END {print count + 0}')"
+    TRAFFIC_OTHER_CURL_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $3 != "0" && $3 != "7" && $3 != "28" {count += 1} END {print count + 0}')"
+    TRAFFIC_OTHER_HTTP_COUNT="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end && $3 == "0" && $2 != "200" && $2 !~ /^5[0-9][0-9]$/ {count += 1} END {print count + 0}')"
+    TRAFFIC_FAILURE_COUNT=$((TRAFFIC_REFUSED_COUNT + TRAFFIC_5XX_COUNT + TRAFFIC_OTHER_CURL_COUNT + TRAFFIC_OTHER_HTTP_COUNT))
     TRAFFIC_FIRST_EPOCH="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end {print $1; exit}')"
     TRAFFIC_LAST_EPOCH="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= end {last = $1} END {print last}')"
+    TRAFFIC_ANOMALY_TIMELINE="$(printf '%s\n' "$logs" | awk -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" -v assertion="$TRAFFIC_ASSERT_EPOCH" '$1 ~ /^[0-9]+$/ && $1 >= start && $1 <= assertion && ($2 != "200" || $3 != "0") {phase = $1 <= end ? "helm-upgrade" : "post-upgrade"; printf "%s phase=%s http=%s curl_exit=%s time_total=%ss\n", $1, phase, $2, $3, $4}')"
 }
 
 TRAFFIC_SAMPLE_COUNT=0
-TRAFFIC_DROP_COUNT=0
-TRAFFIC_DROP_DETAILS=""
+TRAFFIC_REFUSED_COUNT=0
+TRAFFIC_TIMEOUT_COUNT=0
+TRAFFIC_5XX_COUNT=0
+TRAFFIC_OTHER_CURL_COUNT=0
+TRAFFIC_OTHER_HTTP_COUNT=0
+TRAFFIC_FAILURE_COUNT=0
 TRAFFIC_FIRST_EPOCH=""
 TRAFFIC_LAST_EPOCH=""
+TRAFFIC_ASSERT_EPOCH=0
+TRAFFIC_ANOMALY_TIMELINE=""
 
 assert_traffic() {
     local monitor_phase
     local window_seconds=$((UPGRADE_END_EPOCH - UPGRADE_START_EPOCH))
+    local bucket_details
+    TRAFFIC_ASSERT_EPOCH="$(date +%s)"
     monitor_phase="$(kubectl get pod -n "$NAMESPACE" "$TRAFFIC_POD" -o jsonpath='{.status.phase}')"
     traffic_counts
+    bucket_details="refused=$TRAFFIC_REFUSED_COUNT timeout=$TRAFFIC_TIMEOUT_COUNT http_5xx=$TRAFFIC_5XX_COUNT other_curl=$TRAFFIC_OTHER_CURL_COUNT other_http=$TRAFFIC_OTHER_HTTP_COUNT"
+    printf 'Traffic phase markers: upgrade_start=%s helm_wait_end=%s assertion=%s samples=%s..%s\n' "$UPGRADE_START_EPOCH" "$UPGRADE_END_EPOCH" "$TRAFFIC_ASSERT_EPOCH" "${TRAFFIC_FIRST_EPOCH:-none}" "${TRAFFIC_LAST_EPOCH:-none}"
+    if [[ -n "$TRAFFIC_ANOMALY_TIMELINE" ]]; then
+        printf 'Traffic anomaly timeline:\n%s\n' "$TRAFFIC_ANOMALY_TIMELINE"
+    else
+        printf 'Traffic anomaly timeline: none\n'
+    fi
     if [[ "$monitor_phase" != "Running" ]]; then
         record_result "FAIL" "Traffic monitor coverage" "the monitor phase is $monitor_phase after the ${window_seconds}s upgrade window"
     elif ((TRAFFIC_SAMPLE_COUNT == 0)); then
         record_result "FAIL" "Traffic" "the monitor captured no upgrade samples"
     elif ((TRAFFIC_FIRST_EPOCH > UPGRADE_START_EPOCH + 1 || TRAFFIC_LAST_EPOCH < UPGRADE_END_EPOCH - 2)); then
         record_result "FAIL" "Traffic monitor coverage" "samples span $TRAFFIC_FIRST_EPOCH to $TRAFFIC_LAST_EPOCH for the $UPGRADE_START_EPOCH to $UPGRADE_END_EPOCH upgrade window"
-    elif ((TRAFFIC_DROP_COUNT <= ALLOWED_DROPS)); then
-        record_result "PASS" "Traffic" "$TRAFFIC_DROP_COUNT of $TRAFFIC_SAMPLE_COUNT requests dropped in ${window_seconds}s; allowance is $ALLOWED_DROPS"
+    elif ((TRAFFIC_FAILURE_COUNT <= ALLOWED_DROPS)); then
+        record_result "PASS" "Traffic" "$TRAFFIC_FAILURE_COUNT of $TRAFFIC_SAMPLE_COUNT requests failed in ${window_seconds}s ($bucket_details); allowance is $ALLOWED_DROPS"
     else
-        record_result "FAIL" "Traffic" "$TRAFFIC_DROP_COUNT of $TRAFFIC_SAMPLE_COUNT requests dropped in ${window_seconds}s (${TRAFFIC_DROP_DETAILS:-unknown codes}); allowance is $ALLOWED_DROPS"
+        record_result "FAIL" "Traffic" "$TRAFFIC_FAILURE_COUNT of $TRAFFIC_SAMPLE_COUNT requests failed in ${window_seconds}s ($bucket_details); allowance is $ALLOWED_DROPS"
     fi
 }
 

--- a/scripts/rehearsal/rehearse.sh
+++ b/scripts/rehearsal/rehearse.sh
@@ -45,6 +45,10 @@ LEDGER_EXISTED_BEFORE=false
 LEDGER_COUNT_BEFORE=0
 UPGRADE_START_EPOCH=0
 UPGRADE_END_EPOCH=0
+ROLLOUT_OBSERVER_PID=""
+ROLLOUT_OBSERVER_FILE=""
+ROLLOUT_DEPLOYMENT_BEFORE=""
+ROLLOUT_DEPLOYMENT_AFTER=""
 DRAIN_APP_NODE=""
 DRAIN_DB_NODE=""
 
@@ -136,6 +140,7 @@ remove_ddl_trigger() {
 cleanup() {
     set +e
     remove_ddl_trigger
+    stop_rollout_observer
     if [[ "$TRAFFIC_CREATED" == "true" ]]; then
         kubectl delete pod -n "$NAMESPACE" "$TRAFFIC_POD" --ignore-not-found --wait=false >/dev/null 2>&1
     fi
@@ -805,20 +810,102 @@ capture_migration_baseline() {
     fi
 }
 
+backend_deployment_rollout_config() {
+    kubectl get deployment -n "$NAMESPACE" "$RELEASE_NAME-backend" -o json |
+        jq -c '{replicas: .spec.replicas, strategy: .spec.strategy, availableReplicas: (.status.availableReplicas // 0), readyReplicas: (.status.readyReplicas // 0), updatedReplicas: (.status.updatedReplicas // 0)}'
+}
+
+start_rollout_observer() {
+    ROLLOUT_OBSERVER_FILE="$TEMP_DIR/backend-rollout.tsv"
+    ROLLOUT_DEPLOYMENT_BEFORE="$(backend_deployment_rollout_config)"
+    (
+        local sample_index=0
+        while true; do
+            local epoch
+            local endpoint_state
+            local pod_state
+            epoch="$(date +%s)"
+            endpoint_state="$(
+                kubectl get endpointslices.discovery.k8s.io -n "$NAMESPACE" -l "kubernetes.io/service-name=$RELEASE_NAME" -o json 2>/dev/null |
+                    jq -c '{
+                        readyAddresses: ([.items[].endpoints[]? | select(.conditions.ready == true) | .addresses[]?] | length),
+                        endpoints: ([.items[].endpoints[]? | {
+                            addresses: .addresses,
+                            ready: (if ((.conditions // {}) | has("ready")) then .conditions.ready else null end),
+                            serving: (if ((.conditions // {}) | has("serving")) then .conditions.serving else null end),
+                            terminating: (if ((.conditions // {}) | has("terminating")) then .conditions.terminating else null end),
+                            pod: (.targetRef.name // null)
+                        }] | sort_by(.pod))
+                    }' 2>/dev/null || printf '{"error":"endpoint-query-failed"}'
+            )"
+            pod_state="$(
+                kubectl get pods -n "$NAMESPACE" -l "app.kubernetes.io/name=lightdash,app.kubernetes.io/instance=$RELEASE_NAME,app.kubernetes.io/component=backend" -o json 2>/dev/null |
+                    jq -c '[.items[] | {
+                        name: .metadata.name,
+                        hash: (.metadata.labels["pod-template-hash"] // null),
+                        phase: (.status.phase // null),
+                        ready: (([.status.conditions[]? | select(.type == "Ready")][0].status) // "Unknown"),
+                        deleting: (.metadata.deletionTimestamp // null)
+                    }] | sort_by(.name)' 2>/dev/null || printf '[{"error":"pod-query-failed"}]'
+            )"
+            printf '%s\t%s\t%s\t%s\n' "$epoch" "$sample_index" "$endpoint_state" "$pod_state"
+            sample_index=$((sample_index + 1))
+            sleep 0.5
+        done
+    ) >"$ROLLOUT_OBSERVER_FILE" &
+    ROLLOUT_OBSERVER_PID=$!
+}
+
+stop_rollout_observer() {
+    if [[ -z "$ROLLOUT_OBSERVER_PID" ]]; then
+        return
+    fi
+    kill "$ROLLOUT_OBSERVER_PID" >/dev/null 2>&1 || true
+    wait "$ROLLOUT_OBSERVER_PID" >/dev/null 2>&1 || true
+    ROLLOUT_OBSERVER_PID=""
+}
+
+print_rollout_timeline() {
+    printf 'Backend Deployment before upgrade: %s\n' "$ROLLOUT_DEPLOYMENT_BEFORE"
+    printf 'Backend Deployment after upgrade: %s\n' "$ROLLOUT_DEPLOYMENT_AFTER"
+    if [[ ! -s "$ROLLOUT_OBSERVER_FILE" ]]; then
+        printf 'Backend rollout timeline: no samples\n'
+        return
+    fi
+    printf 'Backend rollout timeline (state changes from 0.5s samples):\n'
+    awk -F '\t' -v start="$UPGRADE_START_EPOCH" -v end="$UPGRADE_END_EPOCH" -v assertion="$TRAFFIC_ASSERT_EPOCH" '
+        $1 ~ /^[0-9]+$/ && $1 >= start && $1 <= assertion {
+            state = $3 FS $4
+            if (state != previous) {
+                phase = $1 <= end ? "helm-upgrade" : "post-upgrade"
+                printf "%s sample=%s phase=%s endpoints=%s pods=%s\n", $1, $2, phase, $3, $4
+                previous = state
+            }
+        }
+    ' "$ROLLOUT_OBSERVER_FILE"
+}
+
 start_traffic_monitor() {
     local initial_samples
+    local observer_samples
     local monitor_command
     # The browser route represents user traffic through the Service without the database-backed diagnostics run by /api/v1/health.
     monitor_command="while true; do epoch=\$(date +%s); output=\$(curl -sS -o /dev/null -w \"%{http_code} %{time_total}\" --max-time 10 http://lightdash:8080/ 2>/dev/null); curl_exit=\$?; set -- \$output; printf \"%s %s %s %s\\n\" \"\$epoch\" \"\${1:-000}\" \"\$curl_exit\" \"\${2:-0}\"; sleep 0.5; done"
     kubectl run -n "$NAMESPACE" "$TRAFFIC_POD" --image=curlimages/curl:8.12.1 --restart=Never --command -- sh -c "$monitor_command" >/dev/null
     TRAFFIC_CREATED=true
     kubectl wait -n "$NAMESPACE" --for=condition=Ready "pod/$TRAFFIC_POD" --timeout=5m >/dev/null
+    start_rollout_observer
     sleep 2
     initial_samples="$(kubectl logs -n "$NAMESPACE" "$TRAFFIC_POD" | awk '$1 ~ /^[0-9]+$/ {count += 1} END {print count + 0}')"
+    observer_samples="$(wc -l <"$ROLLOUT_OBSERVER_FILE" | tr -d '[:space:]')"
     if ((initial_samples < 2)); then
         fail "Traffic monitor setup" "the monitor produced only $initial_samples samples before the upgrade"
     fi
+    if ((observer_samples < 2)) || ! kill -0 "$ROLLOUT_OBSERVER_PID" >/dev/null 2>&1; then
+        fail "Rollout observer setup" "the observer produced $observer_samples samples before the upgrade"
+    fi
     record_result "PASS" "Traffic monitor setup" "the monitor produced $initial_samples samples before the upgrade"
+    record_result "PASS" "Rollout observer setup" "the observer produced $observer_samples samples before the upgrade"
 }
 
 assert_helm_deployed() {
@@ -946,6 +1033,8 @@ assert_traffic() {
     local window_seconds=$((UPGRADE_END_EPOCH - UPGRADE_START_EPOCH))
     local bucket_details
     TRAFFIC_ASSERT_EPOCH="$(date +%s)"
+    stop_rollout_observer
+    ROLLOUT_DEPLOYMENT_AFTER="$(backend_deployment_rollout_config)"
     monitor_phase="$(kubectl get pod -n "$NAMESPACE" "$TRAFFIC_POD" -o jsonpath='{.status.phase}')"
     traffic_counts
     bucket_details="refused=$TRAFFIC_REFUSED_COUNT timeout=$TRAFFIC_TIMEOUT_COUNT http_5xx=$TRAFFIC_5XX_COUNT other_curl=$TRAFFIC_OTHER_CURL_COUNT other_http=$TRAFFIC_OTHER_HTTP_COUNT"
@@ -955,6 +1044,7 @@ assert_traffic() {
     else
         printf 'Traffic anomaly timeline: none\n'
     fi
+    print_rollout_timeline
     if [[ "$monitor_phase" != "Running" ]]; then
         record_result "FAIL" "Traffic monitor coverage" "the monitor phase is $monitor_phase after the ${window_seconds}s upgrade window"
     elif ((TRAFFIC_SAMPLE_COUNT == 0)); then

--- a/scripts/rehearsal/rehearse.sh
+++ b/scripts/rehearsal/rehearse.sh
@@ -461,7 +461,7 @@ highest_released_version_before() {
 
 chart_version_for_source() {
     local source="$1"
-    chart_metadata "$source" | awk '$1 == "version:" {gsub(/"/, "", $2); print $2}'
+    chart_metadata "$source" | awk '/^version:/ {gsub(/"/, "", $2); print $2}'
 }
 
 resolve_sources() {


### PR DESCRIPTION
## What this does

This PR makes chart CI rehearse what customers do, and it gates the auto-release on the result. It stacks on #149 and consumes its rehearsal harness.

### Pull request testing (`lint-and-test-charts.yml`)

* Every PR now runs a fresh-install rehearsal and an upgrade rehearsal (latest released chart → the PR's chart) on each matrix entry.
* The matrix moves from EOL Kubernetes 1.21–1.23 to current kind images: v1.33.7, v1.34.3, v1.35.0.
* Helm moves from 3.7.2 to 3.21.4. Actions move from 2021 versions to current pinned releases.
* The `automerge` job is unchanged.

### Release gating (`ci-release.yml`)

* The auto-bump bot pushes releases straight to main many times a day. These releases shipped with zero testing.
* A `test` job now runs the same install and upgrade rehearsals on push to main. The `release` job requires it. A red rehearsal stops the release.
* A concurrency group queues racing pushes so releases stay ordered.

## Known red until #147 lands

The upgrade rehearsal asserts zero dropped requests during the roll. Current main drops requests on a single-replica install because pods stop taking traffic without a pre-stop drain. PR #147 contains the fix. The upgrade test stays red until it lands. This is the gate working, not a flake.

Fresh installs on current main also need S3 settings the default values do not provide (SPK-1102). The rehearsal values provide them through an in-cluster MinIO, so the rehearsal installs succeed where the old `ct install` failed.

## Notes

* `ct lint` stays for chart linting. The unused `ct-install` config file is removed.
* Version research: Kubernetes 1.33–1.35 are the three newest stable minors; kindest/node tags verified on Docker Hub; all action tags verified to exist.

Linear: SPK-1080
