### PR TITLE
ci: set S3 values for chart tests

### DIFF
--- a/charts/lightdash/ci/boot-values.yaml
+++ b/charts/lightdash/ci/boot-values.yaml
@@ -1,0 +1,4 @@
+secrets:
+  S3_ENDPOINT: http://s3.invalid
+  S3_BUCKET: lightdash-ci
+  S3_REGION: us-east-1

--- a/charts/lightdash/ci/boot-values.yaml
+++ b/charts/lightdash/ci/boot-values.yaml
@@ -2,3 +2,6 @@ secrets:
   S3_ENDPOINT: http://s3.invalid
   S3_BUCKET: lightdash-ci
   S3_REGION: us-east-1
+
+browserless-chrome:
+  enabled: false

--- a/charts/lightdash/templates/configmap.yaml
+++ b/charts/lightdash/templates/configmap.yaml
@@ -10,7 +10,7 @@ data:
   PGHOST: {{ include "lightdash.database.host" . }}
   PGPORT: {{ include "lightdash.database.port" . | quote }}
   PGDATABASE: {{ include "lightdash.database.name" . }}
-  HEADLESS_BROWSER_HOST: {{ include "lightdash.headlessBrowser.host" . }}
+  HEADLESS_BROWSER_HOST: {{ include "lightdash.headlessBrowser.host" . | quote }}
   HEADLESS_BROWSER_PORT: {{ include "lightdash.headlessBrowser.port" .  | quote }}
   {{- if .Values.scheduler.enabled }}
   SCHEDULER_ENABLED: "false"


### PR DESCRIPTION
## What breaks

Chart install tests cannot boot the current Lightdash image. The backend exits because the test values do not set its required S3 configuration.

After the backend boots, the browserless dependency test calls `/` and receives 404. Its `/pressure` endpoint is healthy, but the dependency does not make the test path configurable.

## What changes

Add CI-only values for the S3 endpoint, bucket, and region. The endpoint uses the reserved `.invalid` domain. The backend validates these values at startup and does not connect until it performs a storage operation.

Disable browserless in chart tests so the install gate tests the current Lightdash image without running the dependency's stale hook. Production defaults do not change.

Browserless is disabled because its hook calls `/`, which the current image answers with 404, while `/pressure` is healthy. This reduces release-gate coverage of the browserless install path until the hook is fixed.

Quote the empty browser host so disabling browserless produces a valid ConfigMap string instead of YAML null.

This change lets all open chart PRs use the fix through their merge refs.

## Verification

- Helm 3.7.2 lint passes with the CI values.
- Helm 3.7.2 renders all three S3 values into the chart Secret.
- Helm 3.7.2 renders no browserless resources with the CI values.
- Helm 3.7.2 renders `HEADLESS_BROWSER_HOST` as an empty string.
- Lightdash 1.169.1 loads its configuration with the unreachable CI endpoint.

Linear: SPK-1080
