### PR TITLE
ci: upgrade the GitHub Actions to versions that run on Node 24

### DIFF
--- a/.github/workflows/generate-helm-docs.yml
+++ b/.github/workflows/generate-helm-docs.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
 
       - name: Generate Helm Docs
         uses: docker://jnorwood/helm-docs:v1.7.0
@@ -18,7 +18,7 @@ jobs:
           args: --chart-search-root /github/workspace
 
       - name: commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4.13.1
+        uses: stefanzweifel/git-auto-commit-action@v7.2.0
         with:
           commit_message: ":robot: update docs [skip ci]"
           repository: .

--- a/.github/workflows/lint-and-test-charts.yml
+++ b/.github/workflows/lint-and-test-charts.yml
@@ -71,18 +71,3 @@ jobs:
 
       - name: Run upgrade rehearsal
         run: scripts/rehearsal/rehearse.sh --to local --skip-cluster
-
-  automerge:
-    needs: [lint, test]
-    if: ${{ contains(github.event.pull_request.labels, 'merge after testing') }}
-    runs-on: ubuntu-22.04
-    steps:
-      - name: automerge
-        uses: "pascalgn/automerge-action@v0.14.3"
-        env:
-          MERGE_LABELS: "merge after testing"
-          MERGE_METHOD: squash
-          MERGE_COMMIT_MESSAGE: pull-request-title
-          MERGE_FORKS: false
-          MERGE_DELETE_BRANCH: true
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
## What this does

The workflows use action versions from 2021 and 2022. These actions run on the node12 and node16 runtimes inside the runner. GitHub removes old runtimes over time. When that happens the chart release stops and the PR checks stop. Self-hosted users who wait for a chart release notice first.

This PR bumps each action to the current major version. It also removes one dead job. It changes no working behaviour.

## The bumps

| Workflow | Action | Before | After | Runtime after |
| -- | -- | -- | -- | -- |
| all | `actions/checkout` | v2, v2.2.0 | v7 | node24 |
| lint-and-test | `actions/setup-python` | v2, python 3.7 | v7, python 3.13 | node24 |
| lint-and-test, ci-release | `azure/setup-helm` | v1 | v5 | node24 |
| lint-and-test | `helm/chart-testing-action` | v2.2.0 | v2.8.0 | composite |
| lint-and-test | `helm/kind-action` | v1.2.0 | v1.14.0 | node24 |
| ci-release | `helm/chart-releaser-action` | v1.1.0 | v1.7.0 | composite |
| generate-helm-docs | `stefanzweifel/git-auto-commit-action` | v4.13.1 | v7.2.0 | node24 |

Every remaining action runs on node24 or runs as a composite action with no Node runtime.

## Removing the automerge job

The `automerge` job never runs, so this PR deletes it and drops `pascalgn/automerge-action` with it. Its condition tests `contains(github.event.pull_request.labels, 'merge after testing')`, but `labels` holds objects and not strings, so the test is always false. The job reports `skipped` in all of the last 25 workflow runs. The action is also a dead end for this upgrade: v0.16.4 is the newest release, it runs on node20, and the repository has no commit since September 2024. `main` has no branch protection and no ruleset, so no required check depends on this job. The workflow keeps its current name to hold the check names steady.

## What stays the same

* The chart releaser runs on a push to main.
* `CR_SKIP_EXISTING: true` stays.
* The kind Kubernetes matrix stays at v1.21.2, v1.22.5 and v1.23.3.
* The helm versions stay at v3.4.0 and v3.7.2.
* The `ct lint` and `ct install` commands stay.
* No chart version changes. This PR needs no chart release.

## Breaking input checks

I compared the `action.yml` inputs at the old tag and the new tag for each action.

* `helm/chart-releaser-action` v1.7.0 adds a `skip_existing` input. The action appends `--skip-existing` only when that input is not empty. The input stays unset, so `cr` reads `CR_SKIP_EXISTING` from the environment as before. The env var keeps working.
* `helm/kind-action` renames `log_level` to `verbosity`. The workflow does not set it. `node_image` and `cluster_name` are unchanged.
* `azure/setup-helm` makes the `token` input optional. Both steps pin an explicit helm version, so the action makes no API call for the latest release.
* `actions/setup-python` v7 does not supply python 3.7. Python 3.7 is end of life. The version moves to 3.13. `chart-testing-action` still needs python because it installs `yamllint` and `yamale` with pip.
* `stefanzweifel/git-auto-commit-action` v7.2.0 keeps every v4 input. The defaults for the commit author change from `GitHub Actions <actions@github.com>` to `github-actions[bot]`. The workflow sets neither, so the docs commit gets the bot identity. This is the only visible change in behaviour.

## Out of scope

`docker://jnorwood/helm-docs:v1.7.0` is a container action. It runs no Node runtime, so this PR leaves it alone.

## Coordination with #150

PR #150 is open. It rewrites `lint-and-test-charts.yml` and `ci-release.yml`, and it already carries most of these bumps. I used the same version strings as #150 so the overlapping lines match.

After #150 lands, two changes in this PR remain new:

* `generate-helm-docs.yml`, which #150 does not touch.
* The removal of the `automerge` job, which #150 keeps.

**This PR must rebase onto main after #150 merges, before it leaves draft.**

Linear: PROD-10245
