### PR TITLE
Keep bundled PostgreSQL stable during upgrades

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.13.4
+version: 2.14.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.13.4](https://img.shields.io/badge/Version-2.13.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.172.0](https://img.shields.io/badge/AppVersion-1.172.0-informational?style=flat-square)
+![Version: 2.14.0](https://img.shields.io/badge/Version-2.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.172.0](https://img.shields.io/badge/AppVersion-1.172.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -19,6 +19,8 @@ If you want to use your own PostgreSQL instance, ensure it has the vector extens
 #### Using the Bitnami PostgreSQL chart
 
 You may wish to use the Bitnami PostgreSQL chart to spin up a development environment. This guidance is for convenience, you'll want to [read the docs](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#installing-the-chart) before deciding how to implement PostgresSQL.
+
+The bundled database is created during chart installation. Helm upgrades do not modify it. Apply changes to `postgresql.*` values manually. The full management migration is planned for the 3.0.0 chart major.
 
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami
@@ -272,7 +274,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | postgresql.auth.password | string | `""` |  |
 | postgresql.auth.secretKeys.userPasswordKey | string | `"password"` |  |
 | postgresql.auth.username | string | `"lightdash"` |  |
-| postgresql.commonAnnotations."helm.sh/hook" | string | `"pre-install,pre-upgrade"` |  |
+| postgresql.commonAnnotations."helm.sh/hook" | string | `"pre-install"` |  |
 | postgresql.commonAnnotations."helm.sh/hook-weight" | string | `"-1"` |  |
 | postgresql.enabled | bool | `true` |  |
 | postgresql.image.registry | string | `"docker.io"` |  |

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -20,6 +20,8 @@ If you want to use your own PostgreSQL instance, ensure it has the vector extens
 
 You may wish to use the Bitnami PostgreSQL chart to spin up a development environment. This guidance is for convenience, you'll want to [read the docs](https://github.com/bitnami/charts/tree/master/bitnami/postgresql/#installing-the-chart) before deciding how to implement PostgresSQL.
 
+The bundled database is created during chart installation. Helm upgrades do not modify it. Apply changes to `postgresql.*` values manually. The full management migration is planned for the 3.0.0 chart major.
+
 ```
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm install lightdashdb bitnami/postgresql --set auth.username=lightdash,auth.password=changeme,auth.database=lightdash

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -281,7 +281,9 @@ postgresql:
     secretKeys:
       userPasswordKey: "password"
   commonAnnotations:
-    helm.sh/hook: pre-install,pre-upgrade
+    ## Create the bundled database during install. Helm upgrades do not modify it.
+    ## Apply postgresql.* changes manually. The full management migration is planned for chart 3.0.0.
+    helm.sh/hook: pre-install
     helm.sh/hook-weight: "-1"
 ## External PostgreSQL configuration
 ## All of these values are only used when postgresql.enabled is set to false


### PR DESCRIPTION
## What changed

Bundled PostgreSQL now runs only as a pre-install hook. The hook weight remains `-1`.

The chart version is 2.14.0.

## Why

The pre-upgrade hook recreated the PostgreSQL StatefulSet during every chart upgrade. This interrupted the database and removed every backend pod from the Service endpoints.

## Operator impact

Helm upgrades no longer modify the bundled database. Apply changes to `postgresql.*` values manually. The full management migration is planned for the 3.0.0 chart major.

## Verification

- Generated the README with helm-docs 1.7.0.
- Ran `helm lint --strict charts/lightdash`.
- Rendered the chart and confirmed all bundled-PostgreSQL resources use only the `pre-install` hook.
- Confirmed the hook weight remains `-1`.

Security triage: LOW (values annotation + docs only), scan waived by orchestrator.

Linear: SPK-1114
