### PR TITLE
feat: migration job can inherit global env and existingSecret

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.14.14
+version: 2.15.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.14.14](https://img.shields.io/badge/Version-2.14.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.182.0](https://img.shields.io/badge/AppVersion-1.182.0-informational?style=flat-square)
+![Version: 2.15.0](https://img.shields.io/badge/Version-2.15.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.182.0](https://img.shields.io/badge/AppVersion-1.182.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -171,7 +171,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | configMap.SECURE_COOKIES | string | `"false"` | Secure Cookies |
 | configMap.SITE_URL | string | `""` | Public URL of your instance including protocol e.g. https://lightdash.myorg.com |
 | configMap.TRUST_PROXY | string | `"false"` | Trust the reverse proxy when setting secure cookies (via the "X-Forwarded-Proto" header) |
-| existingSecret | string | `""` | Name of an existing Kubernetes secret to inject into all pods via envFrom. Takes precedence over .Values.secrets when set. |
+| existingSecret | string | `""` | Name of an existing Kubernetes secret to inject into all pods except the migration Job unless migrationJob.inheritGlobalEnv is true. Takes precedence over .Values.secrets when set. |
 | externalDatabase.database | string | `"lightdash"` |  |
 | externalDatabase.existingSecret | string | `""` |  |
 | externalDatabase.host | string | `"localhost"` |  |
@@ -225,6 +225,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | migrationJob.extraEnv | list | `[]` |  |
 | migrationJob.extraVolumeMounts | list | `[]` |  |
 | migrationJob.extraVolumes | list | `[]` |  |
+| migrationJob.inheritGlobalEnv | bool | `false` | When true, the migration Job also receives the top-level extraEnv and existingSecret, so env supplied globally (for example LIGHTDASH_LICENSE_KEY) reaches the migrator. Default false keeps current behaviour. |
 | migrationJob.podAnnotations | object | `{}` |  |
 | migrationJob.resources | object | `{}` |  |
 | migrationJob.serviceAccount.annotations | object | `{}` |  |

--- a/charts/lightdash/templates/migrationJob.yaml
+++ b/charts/lightdash/templates/migrationJob.yaml
@@ -54,12 +54,21 @@ spec:
                   name: {{ include "lightdash.database.secretName" . }}
                   key: {{ include "lightdash.database.secret.passwordKey" . }}
             {{- include "lightdash.migrationJobSslEnvs" . | nindent 12 }}
+            {{- if .Values.migrationJob.inheritGlobalEnv }}
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.migrationJob.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "lightdash.fullname" . }}-migration-configmap
+            {{- if and .Values.migrationJob.inheritGlobalEnv .Values.existingSecret }}
+            - secretRef:
+                name: {{ .Values.existingSecret }}
+            {{- end }}
             {{- if .Values.migrationJob.existingSecret }}
             - secretRef:
                 name: {{ .Values.migrationJob.existingSecret }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -32,7 +32,7 @@ secrets:
   # -- 	This is the secret used to sign the session ID cookie and to encrypt sensitive information. Do not share this secret!
   LIGHTDASH_SECRET: changeme
 
-# -- Name of an existing Kubernetes secret to inject into all pods via envFrom. Takes precedence over .Values.secrets when set.
+# -- Name of an existing Kubernetes secret to inject into all pods except the migration Job unless migrationJob.inheritGlobalEnv is true. Takes precedence over .Values.secrets when set.
 existingSecret: ""
 
 extraEnv: []
@@ -336,6 +336,8 @@ ssl:
 ## @param migrationJob.serviceAccount.annotations Annotations on the migration ServiceAccount (e.g. workload identity)
 migrationJob:
   enabled: false
+  # -- When true, the migration Job also receives the top-level extraEnv and existingSecret, so env supplied globally (for example LIGHTDASH_LICENSE_KEY) reaches the migrator. Default false keeps current behaviour.
+  inheritGlobalEnv: false
   existingSecret: ""
   backoffLimit: 10
   ttlSecondsAfterFinished: 100


### PR DESCRIPTION
## What breaks

Enterprise installs with the migration Job enabled miss enterprise migrations when the Job does not receive a globally supplied license key.

## What changes

This adds `migrationJob.inheritGlobalEnv`. It inherits the top-level `extraEnv` and `existingSecret` when enabled. The default is `false`, so this change is additive. The default flips in the chart major.

## Verification

- Render the migration Job with inheritance enabled and confirm the global env and secret order.
- Render with inheritance disabled and compare the Job byte for byte with `origin/main`.
- Render the chart with default values.
- Run `helm lint charts/lightdash`.

Linear: SPK-1085