### PR TITLE
feat: report helm install type and chart version in telemetry env

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.15.3
+version: 2.16.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.15.3](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.184.0](https://img.shields.io/badge/AppVersion-1.184.0-informational?style=flat-square)
+![Version: 2.16.0](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.184.0](https://img.shields.io/badge/AppVersion-1.184.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.15.3](https://img.shields.io/badge/Version-2.15.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.184.0](https://img.shields.io/badge/AppVersion-1.184.0-informational?style=flat-square)
+![Version: 2.15.3](https://img.shields.io/badge/Version-2.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.184.0](https://img.shields.io/badge/AppVersion-1.184.0-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/templates/configmap.yaml
+++ b/charts/lightdash/templates/configmap.yaml
@@ -32,5 +32,14 @@ data:
   {{- if .Values.nats.enabled }}
   NATS_URL: {{ include "lightdash.nats.url" . }}
   {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_INSTALL_TYPE }}
+  LIGHTDASH_INSTALL_TYPE: "helm"
+  {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_HELM_CHART_VERSION }}
+  LIGHTDASH_HELM_CHART_VERSION: {{ .Chart.Version | quote }}
+  {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_MIGRATION_EXECUTION_MODE }}
+  LIGHTDASH_MIGRATION_EXECUTION_MODE: "helm-boot"
+  {{- end }}
   {{- toYaml .Values.configMap | nindent 2 }}
 {{- end }}

--- a/charts/lightdash/templates/migrationConfigMap.yaml
+++ b/charts/lightdash/templates/migrationConfigMap.yaml
@@ -17,5 +17,14 @@ data:
   {{- if .Values.nats.enabled }}
   NATS_URL: {{ include "lightdash.nats.url" . }}
   {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_INSTALL_TYPE }}
+  LIGHTDASH_INSTALL_TYPE: "helm"
+  {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_HELM_CHART_VERSION }}
+  LIGHTDASH_HELM_CHART_VERSION: {{ .Chart.Version | quote }}
+  {{- end }}
+  {{- if not .Values.configMap.LIGHTDASH_MIGRATION_EXECUTION_MODE }}
+  LIGHTDASH_MIGRATION_EXECUTION_MODE: "helm-job"
+  {{- end }}
   {{- toYaml .Values.configMap | nindent 2 }}
 {{- end }}


### PR DESCRIPTION
## What

The chart now identifies itself to upgrade telemetry. Three guarded defaults land in the ConfigMaps:

- `LIGHTDASH_INSTALL_TYPE: helm` (both ConfigMaps)
- `LIGHTDASH_HELM_CHART_VERSION: <chart version>` (both ConfigMaps)
- `LIGHTDASH_MIGRATION_EXECUTION_MODE`: `helm-boot` in the main ConfigMap (entrypoint migrations on backend pods), `helm-job` in the migration ConfigMap (migration Job runs)

## Why

Upgrade events cannot tell a Helm install from any other install today. The server already reads these variables. With this change, helm installs and migration-Job runs become distinguishable in the telemetry.

## Behaviour guard

Each default renders only when the operator does not set the same key in `.Values.configMap`. A user-supplied value always wins and no duplicate keys render. Deployments that set an explicit install type keep it.

## Verification

- Default render with the migration Job enabled shows all three variables with the correct per-ConfigMap values.
- Render with `configMap.LIGHTDASH_INSTALL_TYPE` and `configMap.LIGHTDASH_MIGRATION_EXECUTION_MODE` overridden shows exactly one key per ConfigMap with the override value.
- `helm lint` passes.

Chart version: 2.16.0.

Linear: SPK-1089