### PR TITLE
feat!: chart 3.0.0-beta.1 — migration Job and readyz by default

### DIFF
--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -12,7 +12,7 @@ version: 3.0.0-beta.1
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: 1.190.0
+appVersion: 1.191.1
 
 maintainers:
     - name: owlas

--- a/charts/lightdash/Chart.yaml
+++ b/charts/lightdash/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.16.6
+version: 3.0.0-beta.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 3.0.0-beta.1](https://img.shields.io/badge/Version-3.0.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.190.0](https://img.shields.io/badge/AppVersion-1.190.0-informational?style=flat-square)
+![Version: 3.0.0-beta.1](https://img.shields.io/badge/Version-3.0.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.191.1](https://img.shields.io/badge/AppVersion-1.191.1-informational?style=flat-square)
 
 ## Prerequisites
 

--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -2,7 +2,7 @@
 
 A Helm chart to deploy lightdash on kubernetes
 
-![Version: 2.16.6](https://img.shields.io/badge/Version-2.16.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.190.0](https://img.shields.io/badge/AppVersion-1.190.0-informational?style=flat-square)
+![Version: 3.0.0-beta.1](https://img.shields.io/badge/Version-3.0.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.190.0](https://img.shields.io/badge/AppVersion-1.190.0-informational?style=flat-square)
 
 ## Prerequisites
 
@@ -208,7 +208,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.livenessProbe.timeoutSeconds | int | `15` |  |
 | lightdashBackend.readinessProbe.failureThreshold | int | `2` |  |
 | lightdashBackend.readinessProbe.initialDelaySeconds | int | `5` |  |
-| lightdashBackend.readinessProbe.path | string | `"/api/v1/health"` |  |
+| lightdashBackend.readinessProbe.path | string | `"/api/v1/readyz"` | Backend readiness probe path. Defaults to /api/v1/readyz, which gates on schema migration state. |
 | lightdashBackend.readinessProbe.periodSeconds | int | `5` |  |
 | lightdashBackend.readinessProbe.timeoutSeconds | int | `5` |  |
 | lightdashBackend.startupProbe | object | `{"failureThreshold":18,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":10}` | Backend startup probe. When migrationJob.enabled is false, size its approximate initialDelaySeconds + (periodSeconds * failureThreshold) budget to cover the 30-minute MIGRATION_WAIT_TIMEOUT_MS default plus the longest expected migration. Enable migrationJob.enabled to run migrations in a hook Job without a startup probe. |
@@ -220,12 +220,12 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.terminationGracePeriodSeconds | int | `90` |  |
 | migrationJob.affinity | object | `{}` |  |
 | migrationJob.backoffLimit | int | `10` |  |
-| migrationJob.enabled | bool | `false` |  |
+| migrationJob.enabled | bool | `true` | Run DB migrations in a pre-install/pre-upgrade hook Job. Enabled by default so the Job is the sole migrator. |
 | migrationJob.existingSecret | string | `""` |  |
 | migrationJob.extraEnv | list | `[]` |  |
 | migrationJob.extraVolumeMounts | list | `[]` |  |
 | migrationJob.extraVolumes | list | `[]` |  |
-| migrationJob.inheritGlobalEnv | bool | `false` | When true, the migration Job also receives the top-level extraEnv and existingSecret, so env supplied globally (for example LIGHTDASH_LICENSE_KEY) reaches the migrator. Default false keeps current behaviour. |
+| migrationJob.inheritGlobalEnv | bool | `true` | Let the migration Job inherit top-level extraEnv and existingSecret. Enabled by default so global env reaches the migrator. |
 | migrationJob.podAnnotations | object | `{}` |  |
 | migrationJob.resources | object | `{}` |  |
 | migrationJob.serviceAccount.annotations | object | `{}` |  |
@@ -356,6 +356,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | ssl.enabled | bool | `false` |  |
 | ssl.mountPath | string | `"/etc/ssl/certs"` |  |
 | tolerations | list | `[]` |  |
+| versionCheck.enabled | bool | `true` | Check that semantic image tags meet the 1.169.1 app-version floor. Set false only to bypass a faulty check. |
 | warehouseNatsWorker.command[0] | string | `"node"` |  |
 | warehouseNatsWorker.command[1] | string | `"dist/natsWorker.js"` |  |
 | warehouseNatsWorker.command[2] | string | `"--stream"` |  |

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -258,6 +258,16 @@ Renders a volumeMount for the SSL certificate if ssl.enabled is true.
 {{- end -}}
 {{- end -}}
 
+{{- define "lightdash.validateAppVersion" -}}
+{{- if .Values.versionCheck.enabled -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion | toString -}}
+{{- $coreVersion := regexFind "^[0-9]+\\.[0-9]+\\.[0-9]+" $tag -}}
+{{- if and $coreVersion (not (semverCompare ">=1.169.1" $coreVersion)) -}}
+{{- fail (printf "Lightdash image tag %q is below the required app-version floor 1.169.1. This chart major defaults readiness to /api/v1/readyz, which requires the corrected readyz semantics. Bypass a faulty check with --set versionCheck.enabled=false." $tag) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
 SSL env vars for the migration Job: migrationJob.ssl when enabled, else top-level ssl.
 */}}

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -1,3 +1,4 @@
+{{- include "lightdash.validateAppVersion" . }}
 {{- $volumes := .Values.lightdashBackend.extraVolumes }}
 {{- $volumeMounts := .Values.lightdashBackend.extraVolumeMounts }}
 apiVersion: apps/v1

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -52,6 +52,10 @@ image:
   pullPolicy: IfNotPresent
   tag: ""
 
+versionCheck:
+  # -- Check that semantic image tags meet the 1.169.1 app-version floor. Set false only to bypass a faulty check.
+  enabled: true
+
 imagePullSecrets: []
 
 podAnnotations: {}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -341,8 +341,8 @@ ssl:
 migrationJob:
   # -- Run DB migrations in a pre-install/pre-upgrade hook Job. Enabled by default so the Job is the sole migrator.
   enabled: true
-  # -- When true, the migration Job also receives the top-level extraEnv and existingSecret, so env supplied globally (for example LIGHTDASH_LICENSE_KEY) reaches the migrator. Default false keeps current behaviour.
-  inheritGlobalEnv: false
+  # -- Let the migration Job inherit top-level extraEnv and existingSecret. Enabled by default so global env reaches the migrator.
+  inheritGlobalEnv: true
   existingSecret: ""
   backoffLimit: 10
   ttlSecondsAfterFinished: 100

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -335,7 +335,8 @@ ssl:
 ## @param migrationJob.serviceAccount.name ServiceAccount name (defaults to `<release-fullname>-migration` when create is true, or `default` when create is false)
 ## @param migrationJob.serviceAccount.annotations Annotations on the migration ServiceAccount (e.g. workload identity)
 migrationJob:
-  enabled: false
+  # -- Run DB migrations in a pre-install/pre-upgrade hook Job. Enabled by default so the Job is the sole migrator.
+  enabled: true
   # -- When true, the migration Job also receives the top-level extraEnv and existingSecret, so env supplied globally (for example LIGHTDASH_LICENSE_KEY) reaches the migrator. Default false keeps current behaviour.
   inheritGlobalEnv: false
   existingSecret: ""
@@ -430,9 +431,8 @@ lightdashBackend:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
-    ## Probe endpoint path. /api/v1/health checks the database on every request.
-    ## /api/v1/readyz (backend only) is TTL-cached and gates on schema migration state.
-    path: /api/v1/health
+    # -- Backend readiness probe path. Defaults to /api/v1/readyz, which gates on schema migration state.
+    path: /api/v1/readyz
   ## Container lifecycle hooks. The default preStop sleep keeps the pod serving
   ## while the Service endpoint removal propagates, so a rollout does not send
   ## requests to a pod that has begun shutting down. 10s is a conventional value


### PR DESCRIPTION
## What changes

- Enable the migration Job by default.
- Use `/api/v1/readyz` for backend readiness by default.
- Let the migration Job inherit global env by default.
- Require app version 1.169.1 or later for semantic image tags.

## Compatibility floor

This chart rejects semantic image tags below 1.169.1 because the major defaults readiness to `/api/v1/readyz`. The check compares the leading `X.Y.Z` core, so tags such as `1.186.0-commercial` pass. Non-semantic tags skip the check. Use `--set versionCheck.enabled=false` only to bypass a faulty check.

## Why this is a pre-release

Helm excludes `3.0.0-beta.1` from normal resolution. Cloud installs it by exact pin for testing. The `.chart-bump-paused` marker pauses automatic chart bumps while the major is prepared. Delete the marker to resume them.

## Verification

| Command | Result |
| --- | --- |
| `helm template charts/lightdash --set image.tag=1.186.0-commercial` | Pass |
| `helm template charts/lightdash --set image.tag=1.186.0` | Pass |
| `helm template charts/lightdash --set image.tag=1.150.0` | Fails with the floor message |
| `helm template charts/lightdash --set image.tag=1.150.0 --set versionCheck.enabled=false` | Pass |
| `helm template charts/lightdash --set image.tag=sha256-abc123` | Pass |

Linear: SPK-1084