### PR TITLE
chore: pause the chart auto-bump and stop marking releases latest

### DIFF
--- a/.chart-bump-paused
+++ b/.chart-bump-paused
@@ -1,0 +1,3 @@
+The chart auto-bump is paused while the 3.0 major is prepared and tested.
+Delete this file to resume it.
+Expires: 2026-09-01. If this file still exists after that date, the pause has been forgotten — resume or extend it deliberately.

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -69,6 +69,8 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
+        with:
+          mark_as_latest: false
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           CR_SKIP_EXISTING: true


### PR DESCRIPTION
The chart auto-bump pushes to main on every app release. A chart PR can conflict within minutes, and a conflicted PR cannot run its CI.

This change adds a root marker that pauses the auto-bump while the 3.0 major is prepared and tested. Delete `.chart-bump-paused` to resume it. The marker expires on 2026-09-01 and requires a deliberate resume or extension.

It also sets `mark_as_latest: false` for chart-releaser. The action defaults to marking releases as Latest, and it does not set `prerelease` on the GitHub release it creates. This prevents `3.0.0-beta.1` from appearing as the repository Latest release. Helm resolution is unaffected: installs and upgrades select the newest stable release unless `--devel` or `--version` is used.

Verification:
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-release.yml'))"` passes.
- `git diff --check` passes.
- `git diff --stat origin/main...HEAD` lists only `.chart-bump-paused` and `.github/workflows/ci-release.yml`.
- No files under `charts/` change.

Linear: SPK-1084