### PR TITLE
feat: default backend readiness to readyz where the app version supports it

### DIFF
--- a/charts/lightdash/README.md
+++ b/charts/lightdash/README.md
@@ -54,6 +54,10 @@ s3:
 
 Set `s3.accessKey` and `s3.secretKey` for development only. For production, create a Kubernetes Secret with `S3_ACCESS_KEY` and `S3_SECRET_KEY`, then set `s3.existingSecret` to its name.
 
+### Backend probe paths
+
+`/api/v1/health` checks database access, `/api/v1/livez` checks process liveness without the database, and `/api/v1/readyz` checks TTL-cached readiness and migration state. Unless `lightdashBackend.readinessProbe.path` is set explicitly, the backend readiness probe uses `/api/v1/readyz` for stable Lightdash versions 1.169.1 and later, including build metadata, and `/api/v1/health` for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
+
 ### Database migration startup budget
 
 The backend image runs database migrations before it starts the HTTP server when `migrationJob.enabled` is `false`. The backend startup probe covers this full startup path.
@@ -221,7 +225,7 @@ If you don't want helm to manage this, you may wish to separately create a secre
 | lightdashBackend.livenessProbe.timeoutSeconds | int | `15` |  |
 | lightdashBackend.readinessProbe.failureThreshold | int | `2` |  |
 | lightdashBackend.readinessProbe.initialDelaySeconds | int | `5` |  |
-| lightdashBackend.readinessProbe.path | string | `"/api/v1/health"` |  |
+| lightdashBackend.readinessProbe.path | string | `""` | Backend probe endpoint path. /api/v1/health checks database access, /api/v1/livez checks process liveness without the database, and /api/v1/readyz checks TTL-cached readiness and migration state. The default is /api/v1/readyz for stable Lightdash versions 1.169.1 and later, including build metadata, and /api/v1/health for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service. |
 | lightdashBackend.readinessProbe.periodSeconds | int | `5` |  |
 | lightdashBackend.readinessProbe.timeoutSeconds | int | `5` |  |
 | lightdashBackend.startupProbe | object | `{"failureThreshold":18,"initialDelaySeconds":5,"periodSeconds":10,"timeoutSeconds":10}` | Backend startup probe. When migrationJob.enabled is false, size its approximate initialDelaySeconds + (periodSeconds * failureThreshold) budget to cover the 30-minute MIGRATION_WAIT_TIMEOUT_MS default plus the longest expected migration. Enable migrationJob.enabled to run migrations in a hook Job without a startup probe. |

--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -55,6 +55,10 @@ s3:
 
 Set `s3.accessKey` and `s3.secretKey` for development only. For production, create a Kubernetes Secret with `S3_ACCESS_KEY` and `S3_SECRET_KEY`, then set `s3.existingSecret` to its name.
 
+### Backend probe paths
+
+`/api/v1/health` checks database access, `/api/v1/livez` checks process liveness without the database, and `/api/v1/readyz` checks TTL-cached readiness and migration state. Unless `lightdashBackend.readinessProbe.path` is set explicitly, the backend readiness probe uses `/api/v1/readyz` for stable Lightdash versions 1.169.1 and later, including build metadata, and `/api/v1/health` for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
+
 ### Database migration startup budget
 
 The backend image runs database migrations before it starts the HTTP server when `migrationJob.enabled` is `false`. The backend startup probe covers this full startup path.

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -191,6 +191,24 @@ Add environment variables to configure database values
 {{- end -}}
 {{- end -}}
 
+{{- define "lightdash.backendReadinessProbePath" -}}
+{{- $configuredPath := .Values.lightdashBackend.readinessProbe.path -}}
+{{- if $configuredPath -}}
+{{- $configuredPath -}}
+{{- else -}}
+{{- $imageTag := .Values.image.tag | default .Chart.AppVersion | toString -}}
+{{- $version := trimPrefix "v" $imageTag -}}
+{{- $semanticVersionPattern := `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$` -}}
+{{- $isSemanticVersion := regexMatch $semanticVersionPattern $version -}}
+{{- $isPrerelease := regexMatch `^[0-9]+\.[0-9]+\.[0-9]+-` $version -}}
+{{- if and $isSemanticVersion (not $isPrerelease) (semverCompare ">=1.169.1" $version) -}}
+/api/v1/readyz
+{{- else -}}
+/api/v1/health
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{/*
  Name of the service account used by the migration hook Job
  */}}

--- a/charts/lightdash/templates/backendDeployment.yaml
+++ b/charts/lightdash/templates/backendDeployment.yaml
@@ -133,7 +133,7 @@ spec:
             successThreshold: {{ .Values.lightdashBackend.readinessProbe.successThreshold }}
             {{- end }}
             httpGet:
-              path: {{ .Values.lightdashBackend.readinessProbe.path | default "/api/v1/health" }}
+              path: {{ include "lightdash.backendReadinessProbePath" . }}
               port: {{ .Values.service.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -448,9 +448,8 @@ lightdashBackend:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
-    ## Probe endpoint path. /api/v1/health checks the database on every request.
-    ## /api/v1/readyz (backend only) is TTL-cached and gates on schema migration state.
-    path: /api/v1/health
+    # -- Backend probe endpoint path. /api/v1/health checks database access, /api/v1/livez checks process liveness without the database, and /api/v1/readyz checks TTL-cached readiness and migration state. The default is /api/v1/readyz for stable Lightdash versions 1.169.1 and later, including build metadata, and /api/v1/health for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
+    path: ""
   ## Container lifecycle hooks. The default preStop sleep keeps the pod serving
   ## while the Service endpoint removal propagates, so a rollout does not send
   ## requests to a pod that has begun shutting down. 10s is a conventional value


### PR DESCRIPTION
## What changes

`helm-charts#145` made the backend readiness path configurable but kept `/api/v1/health` as the default. That endpoint queries the database on every probe, so a brief database blip fails every pod at once, and nothing gates readiness on schema state.

The default now resolves from the effective image tag (`image.tag`, falling back to `Chart.AppVersion`):

- a stable semantic version `>= 1.169.1` renders `/api/v1/readyz`
- anything else renders `/api/v1/health`, exactly as today
- an explicit `lightdashBackend.readinessProbe.path` always wins, in both directions

Startup and liveness are untouched. Worker probes are untouched: workers serve a different handler at `/api/v1/health` and do not serve `/api/v1/readyz` at all.

## Why it is gated

`/api/v1/livez` and `/api/v1/readyz` exist from Lightdash `1.129.0`. But readyz reported working pods as not ready during a **parked** migration until `1.169.1`, so a single parked migration removed every backend pod from the load balancer. Flipping the default without a version gate would hand that outage to anyone running `1.129.0` to `1.168.x`.

The chart never guesses. A tag it cannot parse falls back to the old default.

## Behaviour change

On `1.169.1` and later, a pod with a pending migration now reports not ready and leaves the load balancer, where before it served against an incomplete schema.

That is the intended improvement: it converts silent schema drift into a visible stalled rollout. Operators who want the previous behaviour set `lightdashBackend.readinessProbe.path: /api/v1/health`.

## Verification

Rendered, not reasoned. Backend deployment only, resolved readiness path:

| case | resolved path |
| --- | --- |
| default (chart appVersion) | `/api/v1/readyz` |
| `image.tag=1.168.0` | `/api/v1/health` |
| `image.tag=1.169.1` | `/api/v1/readyz` |
| `image.tag=v1.170.0` | `/api/v1/readyz` |
| `image.tag=latest` | `/api/v1/health` |
| `image.tag=""` | `/api/v1/readyz` |
| `image.tag=sha-abc123` | `/api/v1/health` |
| `image.tag=1.170.0-rc.1` | `/api/v1/health` |
| explicit `path=/api/v1/health`, tag `1.180.0` | `/api/v1/health` |
| explicit `path=/api/v1/readyz`, tag `1.100.0` | `/api/v1/readyz` |

`helm lint` passes. `helm template -f ci/boot-values.yaml` still renders.

The leading-`v` case is called out because a previous implementation of a similar version check treated `v`-prefixed tags as non-semver and skipped the check entirely.

## Note

`Chart.yaml` is deliberately untouched. The release bot rewrites it many times a day, so a branch that edits it cannot stay mergeable.

Linear: SPK-1148