### PR TITLE
fix: treat a -commercial image tag as its released version

### DIFF
--- a/charts/lightdash/README.md.gotmpl
+++ b/charts/lightdash/README.md.gotmpl
@@ -57,7 +57,7 @@ Set `s3.accessKey` and `s3.secretKey` for development only. For production, crea
 
 ### Backend probe paths
 
-`/api/v1/health` checks database access, `/api/v1/livez` checks process liveness without the database, and `/api/v1/readyz` checks TTL-cached readiness and migration state. Unless `lightdashBackend.readinessProbe.path` is set explicitly, the backend readiness probe uses `/api/v1/readyz` for stable Lightdash versions 1.169.1 and later, including build metadata, and `/api/v1/health` for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
+`/api/v1/health` checks database access, `/api/v1/livez` checks process liveness without the database, and `/api/v1/readyz` checks TTL-cached readiness and migration state. Unless `lightdashBackend.readinessProbe.path` is set explicitly, the backend readiness probe uses `/api/v1/readyz` for released Lightdash versions 1.169.1 and later, including the known `-commercial` build variant and `+` build metadata, and `/api/v1/health` for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
 
 ### Database migration startup budget
 

--- a/charts/lightdash/templates/_helpers.tpl
+++ b/charts/lightdash/templates/_helpers.tpl
@@ -198,6 +198,10 @@ Add environment variables to configure database values
 {{- else -}}
 {{- $imageTag := .Values.image.tag | default .Chart.AppVersion | toString -}}
 {{- $version := trimPrefix "v" $imageTag -}}
+{{- $knownBuildVariantPattern := `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)-commercial(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$` -}}
+{{- if regexMatch $knownBuildVariantPattern $version -}}
+{{- $version = regexReplaceAll `-commercial` $version "" -}}
+{{- end -}}
 {{- $semanticVersionPattern := `^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*)(\.(0|[1-9][0-9]*|[0-9]*[A-Za-z-][0-9A-Za-z-]*))*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$` -}}
 {{- $isSemanticVersion := regexMatch $semanticVersionPattern $version -}}
 {{- $isPrerelease := regexMatch `^[0-9]+\.[0-9]+\.[0-9]+-` $version -}}

--- a/charts/lightdash/values.yaml
+++ b/charts/lightdash/values.yaml
@@ -448,7 +448,7 @@ lightdashBackend:
     timeoutSeconds: 5
     periodSeconds: 5
     failureThreshold: 2
-    # -- Backend probe endpoint path. /api/v1/health checks database access, /api/v1/livez checks process liveness without the database, and /api/v1/readyz checks TTL-cached readiness and migration state. The default is /api/v1/readyz for stable Lightdash versions 1.169.1 and later, including build metadata, and /api/v1/health for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
+    # -- Backend probe endpoint path. /api/v1/health checks database access, /api/v1/livez checks process liveness without the database, and /api/v1/readyz checks TTL-cached readiness and migration state. The default is /api/v1/readyz for released Lightdash versions 1.169.1 and later, including the known -commercial build variant and + build metadata, and /api/v1/health for earlier, prerelease, or unrecognised versions. Before 1.169.1, a parked migration could remove working pods from service.
     path: ""
   ## Container lifecycle hooks. The default preStop sleep keeps the pod serving
   ## while the Service endpoint removal propagates, so a rollout does not send


### PR DESCRIPTION
## The defect

helm-charts#161 taught the chart to choose the backend readiness endpoint from the image tag: a stable version `>= 1.169.1` gets `/api/v1/readyz`, anything unconfirmed gets `/api/v1/health`.

It excluded **every** prerelease, using semver's rule that any text after a hyphen marks one. That is correct for an unfinished build like `1.170.0-rc.1`.

It is wrong for a **build variant**. Lightdash Cloud runs tags like `1.202.10-commercial`, and self-hosted Enterprise uses the same image line. That is not an unfinished build, it is the same released version built for paying customers.

Rendering all 155 Cloud customer configurations against chart `2.16.28` confirmed it: every single one resolved to `/api/v1/health`. The change shipped in #161 reached nobody who runs a commercial image.

## The fix

Strip a known `-commercial` suffix and read the version underneath. Nothing else changes.

An allow-list of known variants is deliberate, rather than trying to classify suffixes in general. The chart should never guess: guessing wrong points a readiness probe at an endpoint the app may not serve, and an explicit path overrides the safe fallback.

## Verification

Rendered, not reasoned. Backend deployment only, resolved readiness path:

| tag | resolves to |
| --- | --- |
| `1.201.0` | `/api/v1/readyz` |
| `1.201.0-commercial` | `/api/v1/readyz` |
| `v1.201.0-commercial` | `/api/v1/readyz` |
| `1.169.1-commercial` | `/api/v1/readyz` |
| `1.168.0-commercial` | `/api/v1/health` |
| `1.170.0-rc.1` | `/api/v1/health` |
| `1.170.0-alpha.2` | `/api/v1/health` |
| `1.170.0-beta` | `/api/v1/health` |
| `1.170.0-nightly` | `/api/v1/health` |
| `latest` | `/api/v1/health` |
| `sha-abc123` | `/api/v1/health` |
| default appVersion | `/api/v1/readyz` |
| empty tag | `/api/v1/readyz` |
| explicit `path=/api/v1/health`, tag `1.201.0` | `/api/v1/health` |
| explicit `path=/api/v1/readyz`, tag `1.100.0` | `/api/v1/readyz` |

`1.168.0-commercial` is the row that matters most: the suffix is stripped, and the version underneath is still below the floor, so it correctly keeps the old endpoint.

`helm lint` passes. `helm template -f ci/boot-values.yaml` still renders.

## Note

`Chart.yaml` is deliberately untouched. The release bot rewrites it many times a day, so a branch that edits it cannot stay mergeable.

Linear: SPK-1082